### PR TITLE
completed making adding pin invisible and new showcase update

### DIFF
--- a/app/src/main/java/com/hover/stax/channels/ChannelsActivity.java
+++ b/app/src/main/java/com/hover/stax/channels/ChannelsActivity.java
@@ -85,8 +85,14 @@ public class ChannelsActivity extends AppCompatActivity {
 	private void saveAndContinue() {
 		channelViewModel.saveSelected();
 		Utils.saveInt(AUTH_CHECK, 1, this);
-		startActivityForResult(new Intent(ChannelsActivity.this, PinsActivity.class), 0);
+		goToMainActivity();
+		//startActivityForResult(new Intent(ChannelsActivity.this, PinsActivity.class), 0);
 	}
+	private void goToMainActivity() {
+		setResult(RESULT_OK, addReturnData(new Intent()));
+		finish();
+	}
+
 
 	@Override
 	public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {

--- a/app/src/main/java/com/hover/stax/home/ShowcaseExecutor.java
+++ b/app/src/main/java/com/hover/stax/home/ShowcaseExecutor.java
@@ -1,12 +1,17 @@
 package com.hover.stax.home;
 
 import android.app.Activity;
+import android.content.Intent;
+import android.util.Log;
 import android.view.View;
 
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.amplitude.api.Amplitude;
 import com.chauthai.swipereveallayout.SwipeRevealLayout;
 import com.hover.stax.R;
+import com.hover.stax.channels.ChannelsActivity;
+import com.hover.stax.database.Constants;
 import com.hover.stax.utils.Utils;
 import com.hover.stax.utils.bubbleshowcase.BubbleShowCase;
 import com.hover.stax.utils.bubbleshowcase.BubbleShowCaseListener;
@@ -24,7 +29,7 @@ class ShowcaseExecutor {
 		root = view;
 	}
 
-	public void startShowcasing() {
+	public void startFullOnboardingShowcasing() {
 		try {
 			BubbleShowCase.Companion.showCase(
 					activity.getString(R.string.onboard_sechead),
@@ -36,6 +41,21 @@ class ShowcaseExecutor {
 		} catch (Exception ignored) {
 		}
 	}
+
+	public void startAddBalanceShowcasing() {
+		try {
+			BubbleShowCase.Companion.showCase(
+					activity.getString(R.string.onboard_addaccounthead),
+					activity.getString(R.string.onboard_addaccountbody),
+					BubbleShowCase.ArrowPosition.TOP,
+					addBalanceListener,
+					root.findViewById(R.id.add_accounts_btn),
+					activity);
+		} catch (Exception igno) {
+			Log.d("STAX_TESTING", "IT FAILED HERE");
+		}
+	}
+
 
 	private void showcaseSecondStage() {
 		openBalance();
@@ -112,4 +132,34 @@ class ShowcaseExecutor {
 			showcaseNextStage(bubbleShowCase);
 		}
 	};
+
+	BubbleShowCaseListener addBalanceListener = new BubbleShowCaseListener() {
+
+		@Override
+		public void onBubbleClick(@NotNull BubbleShowCase bubbleShowCase) {
+
+		}
+
+		@Override
+		public void onBackgroundDimClick(@NotNull BubbleShowCase bubbleShowCase) {
+
+		}
+
+		@Override
+		public void onCloseActionImageClick(@NotNull BubbleShowCase bubbleShowCase) {
+			goToAddAccountActivity();
+			bubbleShowCase.dismiss();
+		}
+
+		@Override
+		public void onTargetClick(@NotNull BubbleShowCase bubbleShowCase) {
+			goToAddAccountActivity();
+			bubbleShowCase.dismiss();
+		}
+	};
+
+	private void goToAddAccountActivity() {
+		Amplitude.getInstance().logEvent(activity.getString(R.string.click_add_account));
+		activity.startActivityForResult(new Intent(activity, ChannelsActivity.class), Constants.ADD_SERVICE);
+	}
 }

--- a/app/src/main/java/com/hover/stax/utils/bubbleshowcase/BubbleShowCase.kt
+++ b/app/src/main/java/com/hover/stax/utils/bubbleshowcase/BubbleShowCase.kt
@@ -424,6 +424,7 @@ class BubbleShowCase(builder: BubbleShowCaseBuilder) {
 						  .titleTextSize(20) //Title text size in SP (default value 16sp)
 						  .descriptionTextSize(20) //Subtitle text size in SP (default value 14sp)
 						  .listener(listener!!)
+
 						  .targetView(v!!).show()
 			}
 	  }

--- a/app/src/main/res/layout/fragment_pin_update.xml
+++ b/app/src/main/res/layout/fragment_pin_update.xml
@@ -29,11 +29,13 @@
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
 					android:text="@string/btn_removeacct"
+				    	android:layout_alignParentEnd="true"
 					android:layout_toStartOf="@id/divider"
 					android:backgroundTint="@color/bright_red"/>
 
 				<View android:id="@+id/divider"
 					android:layout_width="@dimen/margin_21"
+				    	android:visibility="gone"
 					android:layout_height="wrap_content"
 					android:background="@color/transparent"
 					android:layout_toStartOf="@+id/editBtn"/>
@@ -43,6 +45,7 @@
 					android:layout_width="wrap_content"
 					android:layout_height="wrap_content"
 					android:text="@string/btn_editpin"
+				    	android:visibility="gone"
 					android:layout_alignParentEnd="true"
 					style="@style/StaxButton"/>
 			</RelativeLayout>

--- a/app/src/main/res/layout/security_card_pins.xml
+++ b/app/src/main/res/layout/security_card_pins.xml
@@ -11,6 +11,7 @@
 		android:text="@string/removepins_dialoghead"
 		android:id="@+id/removePinsButtonId"
 		style="@style/StaxButton"
+	      android:visibility="gone"
 		android:backgroundTint="@color/bright_red"
 		android:fontFamily="font-medium" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,6 +146,8 @@
 	</string-array>
 
 	<!-- Onboarding showcase -->
+	<string name="onboard_addaccounthead">Add an account to get started</string>
+	<string name="onboard_addaccountbody">Stax supercharges your bank and mobile money accounts in one secure place</string>
 	<string name="onboard_sechead">World class security</string>
 	<string name="onboard_secbody">We secure Stax with the same technology that locks your device. You unlock Stax the same way you unlock your device</string>
 	<string name="onboard_peekhead">Keep accounts private</string>


### PR DESCRIPTION
- Removed PIN management from settings.
- Go from adding accounts back to home page, instead of showing the PIN screen
- Make add account showcase show whenever the balance is empty;
- Make remaining showcase run after adding accounts.