### PR TITLE
178201080 balance animation with custom cards

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.hover.stax">
+        xmlns:tools="http://schemas.android.com/tools"
+        package="com.hover.stax">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
@@ -19,6 +20,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+            tools:replace="android:allowBackup"
         android:theme="@style/StaxTheme">
 
         <activity

--- a/app/src/main/java/com/hover/stax/balances/BalanceCardStackAdapter.java
+++ b/app/src/main/java/com/hover/stax/balances/BalanceCardStackAdapter.java
@@ -1,0 +1,44 @@
+package com.hover.stax.balances;
+
+import android.content.Context;
+import android.view.ViewGroup;
+
+import androidx.cardview.widget.CardView;
+
+import com.hover.stax.channels.Channel;
+import com.hover.stax.databinding.StackBalanceCardBinding;
+import com.hover.stax.utils.UIHelper;
+import com.hover.stax.views.staxcardstack.StaxCardStackAdapter;
+import com.hover.stax.views.staxcardstack.StaxCardStackView;
+
+class BalanceCardStackAdapter extends StaxCardStackAdapter<Channel> {
+
+    public BalanceCardStackAdapter(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void bindView(Channel channel, int pos, StaxCardStackView.ViewHolder holder) {
+        if(holder instanceof MyViewHolder) {
+            String hex = channel.primaryColorHex;
+            ((MyViewHolder) holder).onBind(hex);
+        }
+    }
+
+    @Override
+    protected StaxCardStackView.ViewHolder onCreateView(ViewGroup parent, int viewType) {
+        return new MyViewHolder(StackBalanceCardBinding.inflate(getLayoutInflater(), parent, false));
+    }
+
+    static class MyViewHolder extends StaxCardStackView.ViewHolder {
+        private final CardView cardView;
+        public MyViewHolder(StackBalanceCardBinding binding) {
+            super(binding.getRoot());
+            cardView = binding.getRoot();
+        }
+        public void onBind(String hex) {
+            cardView.setCardBackgroundColor(UIHelper.getColor(hex, false, getContext()));
+        }
+    }
+
+}

--- a/app/src/main/java/com/hover/stax/balances/BalancesFragment.java
+++ b/app/src/main/java/com/hover/stax/balances/BalancesFragment.java
@@ -20,7 +20,6 @@ import com.hover.stax.databinding.FragmentBalanceBinding;
 import com.hover.stax.home.MainActivity;
 import com.hover.stax.navigation.NavigationInterface;
 import com.hover.stax.utils.UIHelper;
-import com.hover.stax.views.staxcardstack.OnSwipeTouchListener;
 import com.hover.stax.views.staxcardstack.StaxCardStackView;
 
 import java.util.ArrayList;
@@ -91,10 +90,10 @@ public class BalancesFragment extends Fragment implements NavigationInterface {
 
         if (status) {
             balanceStack.setVisibility(GONE);
-            binding.homeCardBalances.balancesMl.transitionToStart();
+            binding.homeCardBalances.balancesMl.transitionToEnd();
         } else {
             balanceStack.setVisibility(VISIBLE);
-            binding.homeCardBalances.balancesMl.transitionToEnd();
+            binding.homeCardBalances.balancesMl.transitionToStart();
         }
 
         balancesVisible = status;

--- a/app/src/main/java/com/hover/stax/balances/BalancesFragment.java
+++ b/app/src/main/java/com/hover/stax/balances/BalancesFragment.java
@@ -122,6 +122,7 @@ public class BalancesFragment extends Fragment implements NavigationInterface {
             cardStackAdapter.updateData(tempChannels);
             balanceStack.setOverlapGaps(STACK_OVERLAY_GAP);
             balanceStack.setRotationX(ROTATE_UPSIDE_DOWN);
+            balanceStack.setOnClickListener(view -> showBalanceCards(!balancesVisible));
             updateBalanceCardStackHeight(tempChannels.size());
         }
     }

--- a/app/src/main/java/com/hover/stax/balances/BalancesFragment.java
+++ b/app/src/main/java/com/hover/stax/balances/BalancesFragment.java
@@ -4,7 +4,6 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.animation.AnimationUtils;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -21,7 +20,11 @@ import com.hover.stax.databinding.FragmentBalanceBinding;
 import com.hover.stax.home.MainActivity;
 import com.hover.stax.navigation.NavigationInterface;
 import com.hover.stax.utils.UIHelper;
+import com.hover.stax.views.staxcardstack.OnSwipeTouchListener;
+import com.hover.stax.views.staxcardstack.StaxCardStackView;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static android.view.View.GONE;
@@ -32,6 +35,8 @@ public class BalancesFragment extends Fragment implements NavigationInterface {
     final private String GREEN_BG = "#46E6CC";
     final private String BLUE_BG = "#04CCFC";
     private boolean SHOW_ADD_ANOTHER_ACCOUNT = false;
+    final private static int STACK_OVERLAY_GAP = 10;
+    final private static int ROTATE_UPSIDE_DOWN = 180;
 
     private BalancesViewModel balancesViewModel;
 
@@ -42,6 +47,7 @@ public class BalancesFragment extends Fragment implements NavigationInterface {
     private RecyclerView balancesRecyclerView;
 
     private FragmentBalanceBinding binding;
+    private StaxCardStackView balanceStack;
 
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         balancesViewModel = new ViewModelProvider(requireActivity()).get(BalancesViewModel.class);
@@ -52,6 +58,7 @@ public class BalancesFragment extends Fragment implements NavigationInterface {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        balanceStack = binding.stackBalanceCards;
         setUpBalances();
         setUpLinkNewAccount();
     }
@@ -69,7 +76,7 @@ public class BalancesFragment extends Fragment implements NavigationInterface {
     private void initBalanceCard() {
         balanceTitle = binding.homeCardBalances.balanceHeaderTitleId;
         balanceTitle.setCompoundDrawablesRelativeWithIntrinsicBounds(balancesVisible ? R.drawable.ic_visibility_on : R.drawable.ic_visibility_off, 0, 0, 0);
-        balanceTitle.setOnClickListener(v -> {
+        balanceTitle.setOnClickListener(view -> {
             showBalanceCards(!balancesVisible);
         });
 
@@ -83,8 +90,10 @@ public class BalancesFragment extends Fragment implements NavigationInterface {
         balanceTitle.setCompoundDrawablesRelativeWithIntrinsicBounds(status ? R.drawable.ic_visibility_on : R.drawable.ic_visibility_off, 0, 0, 0);
 
         if (status) {
+            balanceStack.setVisibility(GONE);
             binding.homeCardBalances.balancesMl.transitionToStart();
         } else {
+            balanceStack.setVisibility(VISIBLE);
             binding.homeCardBalances.balancesMl.transitionToEnd();
         }
 
@@ -99,6 +108,28 @@ public class BalancesFragment extends Fragment implements NavigationInterface {
         balanceAdapter.showBalanceAmounts(true);
 
         showBalanceCards(Channel.areAllDummies(channels));
+        updateStackCard(channels);
+
+
+    }
+    private void updateStackCard(List<Channel> channels) {
+        if(channels !=null) {
+            List<Channel> tempChannels = new ArrayList<>(channels);
+            Collections.reverse(tempChannels);
+
+            BalanceCardStackAdapter cardStackAdapter = new BalanceCardStackAdapter(requireContext());
+            balanceStack.setAdapter (cardStackAdapter);
+            cardStackAdapter.updateData(tempChannels);
+            balanceStack.setOverlapGaps(STACK_OVERLAY_GAP);
+            balanceStack.setRotationX(ROTATE_UPSIDE_DOWN);
+            updateBalanceCardStackHeight(tempChannels.size());
+        }
+    }
+
+    private void updateBalanceCardStackHeight(int numOfItems) {
+        ViewGroup.LayoutParams params = balanceStack.getLayoutParams();
+        params.height = 20 * numOfItems;
+        balanceStack.setLayoutParams(params);
     }
 
     private void addDummyChannelsIfRequired(@Nullable List<Channel> channels) {

--- a/app/src/main/java/com/hover/stax/channels/ChannelsListFragment.java
+++ b/app/src/main/java/com/hover/stax/channels/ChannelsListFragment.java
@@ -76,7 +76,7 @@ public class ChannelsListFragment extends Fragment implements ChannelsRecyclerVi
     private void setupSimSupportedChannels() {
         RecyclerView simSupportedChannelsListView = binding.simSupportedChannelsRecyclerView;
         simSupportedChannelsListView.setLayoutManager(UIHelper.setMainLinearManagers(requireContext()));
-        channelsViewModel.getChannels().observe(getViewLifecycleOwner(), channels -> {
+        channelsViewModel.getSimChannels().observe(getViewLifecycleOwner(), channels -> {
             if(channels!=null) {
                 simSupportedChannelsListView.setAdapter(new ChannelsRecyclerViewAdapter(Channel.sort(channels, false), this));
             }

--- a/app/src/main/java/com/hover/stax/channels/ChannelsListFragment.java
+++ b/app/src/main/java/com/hover/stax/channels/ChannelsListFragment.java
@@ -76,7 +76,7 @@ public class ChannelsListFragment extends Fragment implements ChannelsRecyclerVi
     private void setupSimSupportedChannels() {
         RecyclerView simSupportedChannelsListView = binding.simSupportedChannelsRecyclerView;
         simSupportedChannelsListView.setLayoutManager(UIHelper.setMainLinearManagers(requireContext()));
-        channelsViewModel.getSimChannels().observe(getViewLifecycleOwner(), channels -> {
+        channelsViewModel.getChannels().observe(getViewLifecycleOwner(), channels -> {
             if(channels!=null) {
                 simSupportedChannelsListView.setAdapter(new ChannelsRecyclerViewAdapter(Channel.sort(channels, false), this));
             }

--- a/app/src/main/java/com/hover/stax/channels/ChannelsListFragment.java
+++ b/app/src/main/java/com/hover/stax/channels/ChannelsListFragment.java
@@ -88,6 +88,7 @@ public class ChannelsListFragment extends Fragment implements ChannelsRecyclerVi
             requireActivity().onBackPressed();
             if(balancesViewModel !=null) balancesViewModel.getActions().observe(getViewLifecycleOwner(), actions -> balancesViewModel.setRunning(channel.id));
     }
+
     private void goToChannelsDetailsScreen(Channel channel) {
         BalanceAdapter.BalanceListener balanceListener = (MainActivity) getActivity();
         if(balanceListener!=null) {

--- a/app/src/main/java/com/hover/stax/views/staxcardstack/OnSwipeTouchListener.java
+++ b/app/src/main/java/com/hover/stax/views/staxcardstack/OnSwipeTouchListener.java
@@ -1,0 +1,66 @@
+package com.hover.stax.views.staxcardstack;
+
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+import android.view.View;
+
+public class OnSwipeTouchListener implements View.OnTouchListener {
+
+    private final GestureDetector gestureDetector = new GestureDetector(new GestureListener());
+
+    public boolean onTouch(final View v, final MotionEvent event) {
+        return gestureDetector.onTouchEvent(event);
+    }
+
+    private final class GestureListener extends GestureDetector.SimpleOnGestureListener {
+
+        private static final int SWIPE_THRESHOLD = 100;
+        private static final int SWIPE_VELOCITY_THRESHOLD = 100;
+
+
+        @Override
+        public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+            boolean result = false;
+            try {
+                float diffY = e2.getY() - e1.getY();
+                float diffX = e2.getX() - e1.getX();
+                if (Math.abs(diffX) > Math.abs(diffY)) {
+                    if (Math.abs(diffX) > SWIPE_THRESHOLD && Math.abs(velocityX) > SWIPE_VELOCITY_THRESHOLD) {
+                        if (diffX > 0) {
+                            result = onSwipeRight();
+                        } else {
+                            result = onSwipeLeft();
+                        }
+                    }
+                } else {
+                    if (Math.abs(diffY) > SWIPE_THRESHOLD && Math.abs(velocityY) > SWIPE_VELOCITY_THRESHOLD) {
+                        if (diffY > 0) {
+                            result = onSwipeBottom();
+                        } else {
+                            result = onSwipeTop();
+                        }
+                    }
+                }
+            } catch (Exception exception) {
+                exception.printStackTrace();
+            }
+            return result;
+        }
+    }
+
+    public boolean onSwipeRight() {
+        return false;
+    }
+
+    public boolean onSwipeLeft() {
+        return false;
+    }
+
+    public boolean onSwipeTop() {
+        return false;
+    }
+
+    public boolean onSwipeBottom() {
+        return false;
+    }
+}

--- a/app/src/main/java/com/hover/stax/views/staxcardstack/StaxCardStackAdapter.java
+++ b/app/src/main/java/com/hover/stax/views/staxcardstack/StaxCardStackAdapter.java
@@ -1,0 +1,59 @@
+package com.hover.stax.views.staxcardstack;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class StaxCardStackAdapter<T> extends StaxCardStackView.Adapter<StaxCardStackView.ViewHolder> {
+
+    private final Context mContext;
+    private final LayoutInflater mInflater;
+    private List<T> mData;
+
+    public StaxCardStackAdapter(Context context) {
+        this.mContext = context;
+        this.mInflater = LayoutInflater.from(context);
+        this.mData = new ArrayList();
+    }
+
+    public void updateData(List<T> data) {
+        this.setData(data);
+        this.notifyDataSetChanged();
+    }
+
+    public void setData(List<T> data) {
+        this.mData.clear();
+        if (data != null) {
+            this.mData.addAll(data);
+        }
+    }
+
+    public LayoutInflater getLayoutInflater() {
+        return this.mInflater;
+    }
+
+    public Context getContext() {
+        return this.mContext;
+    }
+
+    @Override
+    public void onBindViewHolder(StaxCardStackView.ViewHolder holder, int position) {
+        T data = this.getItem(position);
+        this.bindView(data, position, holder);
+    }
+
+    public abstract void bindView(T data, int position, StaxCardStackView.ViewHolder holder);
+
+    @Override
+    public int getItemCount() {
+        return mData.size();
+    }
+
+    public T getItem(int position) {
+        return this.mData.get(position);
+    }
+
+}

--- a/app/src/main/java/com/hover/stax/views/staxcardstack/StaxCardStackView.java
+++ b/app/src/main/java/com/hover/stax/views/staxcardstack/StaxCardStackView.java
@@ -1,0 +1,277 @@
+package com.hover.stax.views.staxcardstack;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.database.Observable;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.hover.stax.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class StaxCardStackView extends ViewGroup {
+    public static final int INVALID_TYPE = -1;
+    private static final String TAG = "CardStackView";
+    static final int DEFAULT_SELECT_POSITION = -1;
+    private int mTotalLength;
+    private int mOverlapGaps;
+    private StaxCardStackAdapter mStaxCardStackAdapter;
+    private final ViewDataObserver mObserver = new ViewDataObserver();
+    private int mShowHeight;
+    private List<ViewHolder> mViewHolders;
+
+    public StaxCardStackView(Context context) {
+        this(context, null);
+    }
+
+    public StaxCardStackView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public StaxCardStackView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context, attrs, defStyleAttr, 0);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public StaxCardStackView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    private void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        TypedArray array = context.obtainStyledAttributes(attrs, R.styleable.CardStackView, defStyleAttr, defStyleRes);
+        setOverlapGaps(array.getDimensionPixelSize(R.styleable.CardStackView_stackOverlapGaps, dp2px(20)));
+        array.recycle();
+
+        mViewHolders = new ArrayList<>();
+    }
+
+    private int dp2px(int value) {
+        final float scale = getContext().getResources().getDisplayMetrics().density;
+        return (int) (value * scale + 0.5f);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        checkContentHeightByParent();
+        measureChild(widthMeasureSpec, heightMeasureSpec);
+    }
+
+    private void checkContentHeightByParent() {
+        View parentView = (View) getParent();
+        mShowHeight = parentView.getMeasuredHeight() - parentView.getPaddingTop() - parentView.getPaddingBottom();
+    }
+
+    private void measureChild(int widthMeasureSpec, int heightMeasureSpec) {
+        int maxWidth = 0;
+        mTotalLength = 0;
+        mTotalLength += getPaddingTop() + getPaddingBottom();
+        for (int i = 0; i < getChildCount(); i++) {
+            final View child = getChildAt(i);
+            measureChildWithMargins(child, widthMeasureSpec, 0, heightMeasureSpec, 0);
+            final int totalLength = mTotalLength;
+            final LayoutParams lp =
+                    (LayoutParams) child.getLayoutParams();
+            if (lp.mHeaderHeight == -1) lp.mHeaderHeight = child.getMeasuredHeight();
+            final int childHeight = lp.mHeaderHeight;
+            mTotalLength = Math.max(totalLength, totalLength + childHeight + lp.topMargin +
+                    lp.bottomMargin);
+            mTotalLength -= mOverlapGaps * 2;
+            final int margin = lp.leftMargin + lp.rightMargin;
+            final int measuredWidth = child.getMeasuredWidth() + margin;
+            maxWidth = Math.max(maxWidth, measuredWidth);
+        }
+
+        mTotalLength += mOverlapGaps * 2;
+        int heightSize = mTotalLength;
+        heightSize = Math.max(heightSize, mShowHeight);
+        int heightSizeAndState = resolveSizeAndState(heightSize, heightMeasureSpec, 0);
+        setMeasuredDimension(resolveSizeAndState(maxWidth, widthMeasureSpec, 0),
+                heightSizeAndState);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        layoutChild();
+    }
+
+    private void layoutChild() {
+        int childTop = getPaddingTop();
+        int childLeft = getPaddingLeft();
+
+        for (int i = 0; i < getChildCount(); i++) {
+            View child = getChildAt(i);
+            final int childWidth = child.getMeasuredWidth();
+            int childHeight = child.getMeasuredHeight();
+
+            final LayoutParams lp =
+                    (LayoutParams) child.getLayoutParams();
+            childTop += lp.topMargin;
+            if (i != 0) {
+                childTop -= mOverlapGaps * 2;
+                child.layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight);
+            } else {
+                child.layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight);
+            }
+            childTop += lp.mHeaderHeight;
+        }
+    }
+
+
+    public void setAdapter(StaxCardStackAdapter staxCardStackAdapter) {
+        mStaxCardStackAdapter = staxCardStackAdapter;
+        mStaxCardStackAdapter.registerObserver(mObserver);
+        refreshView();
+    }
+
+    private void refreshView() {
+        removeAllViews();
+        mViewHolders.clear();
+        for (int i = 0; i < mStaxCardStackAdapter.getItemCount(); i++) {
+            ViewHolder holder = getViewHolder(i);
+            holder.position = i;
+            addView(holder.itemView);
+            mStaxCardStackAdapter.bindViewHolder(holder, i);
+        }
+        requestLayout();
+    }
+
+    ViewHolder getViewHolder(int i) {
+        if (i == DEFAULT_SELECT_POSITION) return null;
+        ViewHolder viewHolder;
+        if (mViewHolders.size() <= i || mViewHolders.get(i).mItemViewType != mStaxCardStackAdapter.getItemViewType(i)) {
+            viewHolder = mStaxCardStackAdapter.createView(this, mStaxCardStackAdapter.getItemViewType(i));
+            mViewHolders.add(viewHolder);
+        } else {
+            viewHolder = mViewHolders.get(i);
+        }
+        return viewHolder;
+    }
+
+    @Override
+    public ViewGroup.LayoutParams generateLayoutParams(AttributeSet attrs) {
+        return new LayoutParams(getContext(), attrs);
+    }
+
+    @Override
+    protected ViewGroup.LayoutParams generateDefaultLayoutParams() {
+        return new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+    }
+
+    @Override
+    protected ViewGroup.LayoutParams generateLayoutParams(ViewGroup.LayoutParams p) {
+        return new LayoutParams(p);
+    }
+
+    @Override
+    protected boolean checkLayoutParams(ViewGroup.LayoutParams p) {
+        return p instanceof LayoutParams;
+    }
+
+    public static class LayoutParams extends MarginLayoutParams {
+
+        public int mHeaderHeight;
+
+        public LayoutParams(Context c, AttributeSet attrs) {
+            super(c, attrs);
+
+            TypedArray array = c.obtainStyledAttributes(attrs, R.styleable.CardStackView);
+            mHeaderHeight = array.getDimensionPixelSize(R.styleable.CardStackView_stackHeaderHeight, -1);
+        }
+
+        public LayoutParams(int width, int height) {
+            super(width, height);
+        }
+
+        public LayoutParams(ViewGroup.LayoutParams source) {
+            super(source);
+        }
+    }
+
+    public static abstract class Adapter<VH extends ViewHolder> {
+        private final AdapterDataObservable mObservable = new AdapterDataObservable();
+
+        VH createView(ViewGroup parent, int viewType) {
+            VH holder = onCreateView(parent, viewType);
+            holder.mItemViewType = viewType;
+            return holder;
+        }
+
+        protected abstract VH onCreateView(ViewGroup parent, int viewType);
+
+        public void bindViewHolder(VH holder, int position) {
+            onBindViewHolder(holder, position);
+        }
+
+        protected abstract void onBindViewHolder(VH holder, int position);
+
+        public abstract int getItemCount();
+
+        public int getItemViewType(int position) {
+            return 0;
+        }
+
+        public final void notifyDataSetChanged() {
+            mObservable.notifyChanged();
+        }
+
+        public void registerObserver(AdapterDataObserver observer) {
+            mObservable.registerObserver(observer);
+        }
+    }
+
+    public static abstract class ViewHolder {
+
+        public View itemView;
+        int mItemViewType = INVALID_TYPE;
+        int position;
+
+        public ViewHolder(View view) {
+            itemView = view;
+        }
+
+        public Context getContext() {
+            return itemView.getContext();
+        }
+    }
+
+    public static class AdapterDataObservable extends Observable<AdapterDataObserver> {
+        public boolean hasObservers() {
+            return !mObservers.isEmpty();
+        }
+
+        public void notifyChanged() {
+            for (int i = mObservers.size() - 1; i >= 0; i--) {
+                mObservers.get(i).onChanged();
+            }
+        }
+    }
+
+    public static abstract class AdapterDataObserver {
+        public void onChanged() {
+        }
+    }
+
+    private class ViewDataObserver extends AdapterDataObserver {
+        @Override
+        public void onChanged() {
+            refreshView();
+        }
+    }
+
+    public void setOverlapGaps(int overlapGaps) {
+        mOverlapGaps = overlapGaps;
+    }
+
+    public int getShowHeight() {
+        return mShowHeight;
+    }
+
+}

--- a/app/src/main/res/layout/fragment_balance.xml
+++ b/app/src/main/res/layout/fragment_balance.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/home_content"
@@ -8,6 +8,14 @@
         android:layout_marginTop="@dimen/margin_13"
         android:orientation="vertical"
         tools:context=".balances.BalancesFragment">
+
+    <com.hover.stax.views.staxcardstack.StaxCardStackView
+            android:id="@+id/stack_balance_cards"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            android:layout_marginHorizontal="@dimen/margin_13"
+            android:layout_marginTop="57dp"
+            />
 
     <include
             android:id="@+id/homeCardBalances"
@@ -20,7 +28,9 @@
             android:layout_marginHorizontal="@dimen/margin_13"
             android:layout_marginBottom="@dimen/margin_13"
             android:visibility="gone"
+            android:animateLayoutChanges="false"
             app:cardBackgroundColor="@color/cardViewColor"
+            android:layout_below="@id/homeCardBalances"
             app:cardCornerRadius="@dimen/radius"
             app:cardElevation="8dp">
 
@@ -36,4 +46,4 @@
                 android:textSize="@dimen/text_16" />
     </androidx.cardview.widget.CardView>
 
-</LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -31,6 +31,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/margin_13"
                 android:layout_marginTop="@dimen/margin_13"
+                android:animateLayoutChanges="false"
                 app:cardBackgroundColor="@color/cardViewColor"
                 app:cardCornerRadius="@dimen/radius"
                 app:cardElevation="8dp">
@@ -54,6 +55,7 @@
                 android:layout_marginTop="@dimen/margin_13"
                 android:layout_marginBottom="@dimen/margin_21"
                 android:clipToPadding="true"
+                android:animateLayoutChanges="false"
                 app:cardBackgroundColor="@color/cardViewColor"
                 app:cardCornerRadius="@dimen/radius"
                 app:cardElevation="8dp">

--- a/app/src/main/res/layout/home_card_balances.xml
+++ b/app/src/main/res/layout/home_card_balances.xml
@@ -38,26 +38,18 @@
 
     </androidx.cardview.widget.CardView>
 
-    <com.google.android.material.card.MaterialCardView
-            android:id="@+id/balances_card"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_13"
-            android:layout_marginTop="@dimen/margin_13"
-            app:cardBackgroundColor="@color/colorPrimaryDark"
-            app:cardCornerRadius="@dimen/radius"
-            app:cardElevation="0dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/balance_header_card">
 
         <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/balances_recyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginHorizontal="2dp"
+                app:cardElevation="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/balance_header_card"
                 tools:itemCount="2"
                 tools:listitem="@layout/balance_item" />
 
-    </com.google.android.material.card.MaterialCardView>
 
 </androidx.constraintlayout.motion.widget.MotionLayout>

--- a/app/src/main/res/layout/home_card_balances.xml
+++ b/app/src/main/res/layout/home_card_balances.xml
@@ -38,18 +38,16 @@
 
     </androidx.cardview.widget.CardView>
 
-
-
-        <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/balances_recyclerView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="2dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/balance_header_card"
-                app:cardElevation="0dp"
-                tools:itemCount="2"
-                tools:listitem="@layout/balance_item" />
+    <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/balances_recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="2dp"
+            app:cardElevation="0dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/balance_header_card"
+            tools:itemCount="2"
+            tools:listitem="@layout/balance_item" />
 
 </androidx.constraintlayout.motion.widget.MotionLayout>

--- a/app/src/main/res/layout/home_card_balances.xml
+++ b/app/src/main/res/layout/home_card_balances.xml
@@ -13,7 +13,7 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/margin_13"
             android:layout_marginTop="@dimen/margin_5"
-            android:layout_marginBottom="5dp"
+            android:layout_marginBottom="@dimen/margin_5"
             android:clipToPadding="true"
             app:cardBackgroundColor="@color/cardViewColor"
             app:cardCornerRadius="@dimen/radius"
@@ -39,17 +39,17 @@
     </androidx.cardview.widget.CardView>
 
 
+
         <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/balances_recyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="2dp"
-                app:cardElevation="0dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/balance_header_card"
+                app:cardElevation="0dp"
                 tools:itemCount="2"
                 tools:listitem="@layout/balance_item" />
-
 
 </androidx.constraintlayout.motion.widget.MotionLayout>

--- a/app/src/main/res/layout/stack_balance_card.xml
+++ b/app/src/main/res/layout/stack_balance_card.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/stack_card"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        app:cardCornerRadius="5dp"
+        app:cardElevation="8dp">
+    <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="2dp" />
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -41,4 +41,9 @@
 		<attr name="top_progress_bar_color_4" format="color|reference" />
 
 	</declare-styleable>
+
+	<declare-styleable name="CardStackView">
+		<attr name="stackOverlapGaps" format="dimension"/>
+		<attr name="stackHeaderHeight" format="dimension"/>
+	</declare-styleable>
 </resources>

--- a/app/src/main/res/xml/home_card_balances_scene.xml
+++ b/app/src/main/res/xml/home_card_balances_scene.xml
@@ -19,7 +19,7 @@
         <Constraint
                 android:id="@id/balances_recyclerView"
                 android:layout_width="match_parent"
-                android:layout_height="65dp"
+                android:layout_height="5dp"
                 android:layout_marginStart="@dimen/margin_13"
                 android:layout_marginEnd="@dimen/margin_13"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/xml/home_card_balances_scene.xml
+++ b/app/src/main/res/xml/home_card_balances_scene.xml
@@ -2,7 +2,7 @@
 <MotionScene xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ConstraintSet android:id="@+id/start">
+    <ConstraintSet android:id="@+id/end">
         <Constraint
                 android:id="@+id/balances_recyclerView"
                 android:layout_width="match_parent"
@@ -15,7 +15,7 @@
                 app:layout_constraintTop_toBottomOf="@id/balance_header_card" />
     </ConstraintSet>
 
-    <ConstraintSet android:id="@+id/end">
+    <ConstraintSet android:id="@+id/start">
         <Constraint
                 android:id="@id/balances_recyclerView"
                 android:layout_width="match_parent"

--- a/app/src/main/res/xml/home_card_balances_scene.xml
+++ b/app/src/main/res/xml/home_card_balances_scene.xml
@@ -4,7 +4,7 @@
 
     <ConstraintSet android:id="@+id/start">
         <Constraint
-                android:id="@+id/balances_card"
+                android:id="@+id/balances_recyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/margin_13"
@@ -17,7 +17,7 @@
 
     <ConstraintSet android:id="@+id/end">
         <Constraint
-                android:id="@id/balances_card"
+                android:id="@id/balances_recyclerView"
                 android:layout_width="match_parent"
                 android:layout_height="65dp"
                 android:layout_marginStart="@dimen/margin_13"


### PR DESCRIPTION
The motionLayout approach itself only shows one(1) collapsed card, even when there are more than 1 balances. Adding motionLayout to each recyclerView item makes it prone to errors as list grows.

Here is an implementation using custom cards which updates visibility when balance cards animation updates either extended or collapsed.

To achieve the visual effect of the stacked card to match design, there was a need to have a separate component and invert the view and entry list.