### PR TITLE
fix for account not adding

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,6 +8,7 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="../../../../layout/custom_preview.xml" value="0.24444444444444444" />
         <entry key="app/src/main/res/drawable/button_bg_colored.xml" value="0.32037037037037036" />
         <entry key="app/src/main/res/drawable/button_bg_dark.xml" value="0.32037037037037036" />
         <entry key="app/src/main/res/drawable/button_bg_grey.xml" value="0.32037037037037036" />

--- a/app/src/main/java/com/hover/stax/channels/AddChannelsFragment.kt
+++ b/app/src/main/java/com/hover/stax/channels/AddChannelsFragment.kt
@@ -22,6 +22,7 @@ import com.hover.stax.utils.network.NetworkMonitor
 import com.hover.stax.views.StaxDialog
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import timber.log.Timber
 
 
 class AddChannelsFragment : Fragment(), ChannelsRecyclerViewAdapter.SelectListener {
@@ -154,7 +155,6 @@ class AddChannelsFragment : Fragment(), ChannelsRecyclerViewAdapter.SelectListen
 
             channelsViewModel.setChannelsSelected(selectedChannels)
             channelsViewModel.createAccounts(selectedChannels)
-
             showCheckBalanceDialog(
                     if (selectedChannels.size > 1) R.string.check_balance_alt_plural
                     else R.string.check_balance_alt,

--- a/app/src/main/java/com/hover/stax/channels/ChannelsViewModel.kt
+++ b/app/src/main/java/com/hover/stax/channels/ChannelsViewModel.kt
@@ -285,18 +285,15 @@ class ChannelsViewModel(val application: Application, val repo: DatabaseRepo) : 
         setActiveChannel(repo.getChannel(s.channel_id)!!)
     }
 
-    fun getFetchAccountAction(channelId: Int): HoverAction? = repo.getActions(channelId, HoverAction.FETCH_ACCOUNTS).firstOrNull()
+    fun getFetchAccountAction(channelId: Int): HoverAction? = repo.getActions(channelId, HoverAction.FETCH_ACCOUNTS) .firstOrNull()
 
     fun createAccounts(channels: List<Channel>) = viewModelScope.launch(Dispatchers.IO) {
         val defaultAccount = repo.getDefaultAccount()
-
         channels.forEach {
-            if (getFetchAccountAction(it.id) == null) {
                 with(it) {
-                    val account = Account(name, name, logoUrl, accountNo, id, primaryColorHex, secondaryColorHex, defaultAccount == null)
-                    repo.insert(account)
+                        val account = Account(name, name, logoUrl, accountNo, id, primaryColorHex, secondaryColorHex, defaultAccount == null)
+                        repo.insert(account)
                 }
-            }
         }
     }
 


### PR DESCRIPTION
- I noticed the cause of the bug is that it tries to fetch if the action is already in a fetch_account list, of which not all account is has a type of fetch_account.

- I think the check is not necessary since the insert method already have a 
 ```
@Insert(onConflict = OnConflictStrategy.REPLACE)
    fun insert(account: Account)
```