### PR TITLE
fees and money out only includes successful txns

### DIFF
--- a/app/src/main/java/com/hover/stax/RoutingActivity.kt
+++ b/app/src/main/java/com/hover/stax/RoutingActivity.kt
@@ -115,7 +115,7 @@ class RoutingActivity : AppCompatActivity(), BiometricChecker.AuthListener, Push
 
     private fun initHover() {
         Hover.initialize(this)
-        Hover.setBranding(getString(R.string.app_name), R.mipmap.stax, this)
+        Hover.setBranding(getString(R.string.app_name), R.mipmap.stax, R.drawable.ic_stax, this)
         Hover.setPermissionActivity(Constants.PERM_ACTIVITY, this)
     }
 

--- a/app/src/main/java/com/hover/stax/accounts/AccountDetailFragment.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDetailFragment.kt
@@ -63,19 +63,19 @@ class AccountDetailFragment : Fragment(), TransactionHistoryAdapter.SelectListen
         viewModel.setAccount(args.accountId)
     }
 
-    private fun setUpBalance() {
-        binding.balanceCard.root.cardElevation = 0F
-        binding.balanceCard.balanceAmount.text = " - "
-        binding.balanceCard.balanceChannelName.setTextColor(ContextCompat.getColor(requireActivity(), R.color.offWhite))
-        binding.balanceCard.balanceAmount.setTextColor(ContextCompat.getColor(requireActivity(), R.color.offWhite))
-        binding.balanceCard.balanceRefreshIcon.setOnClickListener { onRefresh() }
+    private fun setUpBalance() = with(binding.balanceCard) {
+        root.cardElevation = 0F
+        balanceAmount.text = " - "
+        balanceChannelName.setTextColor(ContextCompat.getColor(requireActivity(), R.color.offWhite))
+        balanceAmount.setTextColor(ContextCompat.getColor(requireActivity(), R.color.offWhite))
+        balanceRefreshIcon.setOnClickListener { onRefresh() }
     }
 
-    private fun setUpManage() {
-        binding.manageCard.nicknameSaveBtn.setOnClickListener { updateNickname() }
-        binding.manageCard.accountSaveBtn.setOnClickListener { updateAccountNumber() }
-        binding.manageCard.nicknameInput.addTextChangedListener(nicknameWatcher)
-        binding.manageCard.accountNumberInput.addTextChangedListener(accountWatcher)
+    private fun setUpManage() = with(binding.manageCard) {
+        nicknameSaveBtn.setOnClickListener { updateNickname() }
+        accountSaveBtn.setOnClickListener { updateAccountNumber() }
+        nicknameInput.addTextChangedListener(nicknameWatcher)
+        accountNumberInput.addTextChangedListener(accountWatcher)
     }
 
     private val nicknameWatcher: TextWatcher = object : TextWatcher {

--- a/app/src/main/java/com/hover/stax/database/DatabaseRepo.kt
+++ b/app/src/main/java/com/hover/stax/database/DatabaseRepo.kt
@@ -151,7 +151,7 @@ class DatabaseRepo(db: AppDatabase, sdkDb: HoverRoomDatabase) {
 
     @SuppressLint("DefaultLocale")
     fun getFees(accountId: Int, year: Int): LiveData<Double>? {
-        return transactionDao.getTotalFees(accountId, year.toString(), Transaction.SUCCEEDED)
+        return transactionDao.getTotalFees(accountId, year.toString())
     }
 
     fun getTransaction(uuid: String?): StaxTransaction? {

--- a/app/src/main/java/com/hover/stax/database/DatabaseRepo.kt
+++ b/app/src/main/java/com/hover/stax/database/DatabaseRepo.kt
@@ -10,6 +10,7 @@ import com.hover.sdk.actions.HoverActionDao
 import com.hover.sdk.database.HoverRoomDatabase
 import com.hover.sdk.sims.SimInfo
 import com.hover.sdk.sims.SimInfoDao
+import com.hover.sdk.transactions.Transaction
 import com.hover.sdk.transactions.TransactionContract
 import com.hover.stax.R
 import com.hover.stax.accounts.Account
@@ -150,7 +151,7 @@ class DatabaseRepo(db: AppDatabase, sdkDb: HoverRoomDatabase) {
 
     @SuppressLint("DefaultLocale")
     fun getFees(accountId: Int, year: Int): LiveData<Double>? {
-        return transactionDao.getTotalFees(accountId, year.toString())
+        return transactionDao.getTotalFees(accountId, year.toString(), Transaction.SUCCEEDED)
     }
 
     fun getTransaction(uuid: String?): StaxTransaction? {

--- a/app/src/main/java/com/hover/stax/transactions/TransactionDao.kt
+++ b/app/src/main/java/com/hover/stax/transactions/TransactionDao.kt
@@ -3,6 +3,7 @@ package com.hover.stax.transactions
 import androidx.lifecycle.LiveData
 import androidx.room.*
 import kotlinx.coroutines.flow.Flow
+import com.hover.sdk.transactions.Transaction as Txn
 
 @Dao
 interface TransactionDao {
@@ -31,11 +32,11 @@ interface TransactionDao {
     @Query("SELECT * FROM stax_transactions WHERE uuid = :uuid LIMIT 1")
     suspend fun getTransactionSuspended(uuid: String?): StaxTransaction?
 
-    @Query("SELECT SUM(amount) as total FROM stax_transactions WHERE strftime('%m', initiated_at/1000, 'unixepoch') = :month AND strftime('%Y', initiated_at/1000, 'unixepoch') = :year AND account_id = :accountId AND status != 'failed' AND environment != 3")
-    fun getTotalAmount(accountId: Int, month: String, year: String): LiveData<Double>?
+    @Query("SELECT SUM(amount) as total FROM stax_transactions WHERE strftime('%m', initiated_at/1000, 'unixepoch') = :month AND strftime('%Y', initiated_at/1000, 'unixepoch') = :year AND account_id = :accountId AND status = :status AND environment != 3")
+    fun getTotalAmount(accountId: Int, month: String, year: String, status: String = Txn.SUCCEEDED): LiveData<Double>?
 
-    @Query("SELECT SUM(fee) as total FROM stax_transactions WHERE strftime('%Y', initiated_at/1000, 'unixepoch') = :year AND account_id = :accountId AND environment != 3")
-    fun getTotalFees(accountId: Int, year: String): LiveData<Double>?
+    @Query("SELECT SUM(fee) as total FROM stax_transactions WHERE strftime('%Y', initiated_at/1000, 'unixepoch') = :year AND account_id = :accountId AND environment != 3 AND status = :status")
+    fun getTotalFees(accountId: Int, year: String, status: String = Txn.SUCCEEDED): LiveData<Double>?
 
     @Query("SELECT COUNT(id) FROM stax_transactions WHERE strftime('%m', initiated_at/1000, 'unixepoch') = :month AND strftime('%Y', initiated_at/1000, 'unixepoch') = :year AND environment != 3")
     suspend fun getTransactionCount(month: String, year: String): Int?


### PR DESCRIPTION
Added a status param to fees and money spent queries with a default value of `Transaction.SUCCEEDED`. Can be overridden with the desired status if required. 