### PR TITLE
182024752 permissions fix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,9 +66,6 @@
                 android:launchMode="singleTask"
                 android:theme="@style/StaxTheme" />
         <activity
-                android:name=".destruct.SelfDestructActivity"
-                android:exported="false" />
-        <activity
                 android:name=".onboarding.OnBoardingActivity"
                 android:exported="false"
                 android:theme="@style/StaxTheme" />

--- a/app/src/main/java/com/hover/stax/balances/BalancesFragment.kt
+++ b/app/src/main/java/com/hover/stax/balances/BalancesFragment.kt
@@ -54,11 +54,11 @@ class BalancesFragment : Fragment() {
         initBalanceCard()
 
         val observer = object : Observer<List<Account>> {
-            override fun onChanged(t: List<Account>?) {
-                if (!t.isNullOrEmpty())
+            override fun onChanged(t: List<Account>) {
                     updateServices(ArrayList(t))
             }
         }
+
         with(balancesViewModel) {
             accounts.observe(viewLifecycleOwner, observer)
             shouldShowBalances.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/hover/stax/balances/BalancesFragment.kt
+++ b/app/src/main/java/com/hover/stax/balances/BalancesFragment.kt
@@ -53,7 +53,12 @@ class BalancesFragment : Fragment() {
     private fun setUpBalances() {
         initBalanceCard()
 
-        val observer = Observer<List<Account>> { t -> updateServices(ArrayList(t)) }
+        val observer = object : Observer<List<Account>> {
+            override fun onChanged(t: List<Account>?) {
+                if (!t.isNullOrEmpty())
+                    updateServices(ArrayList(t))
+            }
+        }
         with(balancesViewModel) {
             accounts.observe(viewLifecycleOwner, observer)
             shouldShowBalances.observe(viewLifecycleOwner) {
@@ -89,7 +94,6 @@ class BalancesFragment : Fragment() {
     }
 
     private fun showBalanceCards(status: Boolean) {
-
         toggleLink(status)
         Utils.saveBoolean(BALANCE_LABEL, status, requireContext())
         balanceTitle.setCompoundDrawablesRelativeWithIntrinsicBounds(

--- a/app/src/main/java/com/hover/stax/home/NavHelper.kt
+++ b/app/src/main/java/com/hover/stax/home/NavHelper.kt
@@ -81,11 +81,7 @@ class NavHelper(val activity: AppCompatActivity) {
 
         when {
             exemptRoutes.contains(it) || permissionHelper.hasBasicPerms() -> NavUtil.navigate(getNavController(), it)
-            else -> PermissionUtils.showInformativeBasicPermissionDialog(
-                0,
-                { PermissionUtils.requestPerms(Constants.PERMS_REQ_CODE, activity) },
-                { AnalyticsUtil.logAnalyticsEvent(activity.getString(R.string.perms_basic_cancelled), activity) }, activity
-            )
+            else -> requestBasicPerms()
         }
     }
 
@@ -100,5 +96,12 @@ class NavHelper(val activity: AppCompatActivity) {
         Constants.NAV_LINK_ACCOUNT -> MainNavigationDirections.actionGlobalAddChannelsFragment()
         Constants.NAV_PAYBILL -> MainNavigationDirections.actionGlobalPaybillFragment(false)
         else -> null //invalid or unmapped route, return nothing
+    }
+
+    fun requestBasicPerms(){
+        PermissionUtils.showInformativeBasicPermissionDialog(
+            0,
+            { PermissionUtils.requestPerms(Constants.PERMS_REQ_CODE, activity) },
+            { AnalyticsUtil.logAnalyticsEvent(activity.getString(R.string.perms_basic_cancelled), activity) }, activity)
     }
 }

--- a/app/src/main/java/com/hover/stax/paybill/PaybillFragment.kt
+++ b/app/src/main/java/com/hover/stax/paybill/PaybillFragment.kt
@@ -186,8 +186,16 @@ class PaybillFragment : Fragment(), PaybillIconsAdapter.IconSelectListener {
     }
 
     private fun setupActionDropdownObservers(viewModel: ChannelsViewModel, lifecycleOwner: LifecycleOwner) {
-        val activeChannelObserver = Observer<Channel?> { Timber.i("Got new active channel: $it ${it?.countryAlpha2}") }
-        val actionsObserver = Observer<List<HoverAction>> { Timber.i("Got new actions: %s", it?.size) }
+        val activeChannelObserver = object: Observer<Channel?> {
+            override fun onChanged(t: Channel?) {
+                Timber.i("Got new active channel: $t ${t?.countryAlpha2}")
+            }
+        }
+        val actionsObserver = object : Observer<List<HoverAction>> {
+            override fun onChanged(t: List<HoverAction>?) {
+                Timber.i("Got new actions: %s", t?.size)
+            }
+        }
 
         viewModel.activeChannel.observe(lifecycleOwner, activeChannelObserver)
         viewModel.channelActions.observe(lifecycleOwner, actionsObserver)

--- a/app/src/main/java/com/hover/stax/permissions/PermissionUtils.kt
+++ b/app/src/main/java/com/hover/stax/permissions/PermissionUtils.kt
@@ -11,12 +11,20 @@ import com.hover.sdk.permissions.PermissionHelper
 import com.hover.stax.R
 import com.hover.stax.utils.AnalyticsUtil.logAnalyticsEvent
 import com.hover.stax.views.StaxDialog
+import timber.log.Timber
 
 object PermissionUtils {
 
     fun requestPerms(requestCode: Int, a: Activity) {
         val ph = PermissionHelper(a)
-        if (!ph.hasPhonePerm() && !ph.hasPhonePerm()) logAnalyticsEvent(a.getString(R.string.perms_basic_requested), a) else if (!ph.hasPhonePerm()) logAnalyticsEvent(a.getString(R.string.perms_phone_requested), a) else if (!ph.hasSmsPerm()) logAnalyticsEvent(a.getString(R.string.perms_sms_requested), a)
+
+        when {
+            !ph.hasPhonePerm() && !ph.hasSmsPerm() -> logAnalyticsEvent(a.getString(R.string.perms_basic_requested), a)
+            !ph.hasPhonePerm() -> logAnalyticsEvent(a.getString(R.string.perms_phone_requested), a)
+            !ph.hasSmsPerm() -> logAnalyticsEvent(a.getString(R.string.perms_sms_requested), a)
+        }
+
+        Timber.e("Requesting basic permissions")
         ph.requestBasicPerms(a, requestCode)
     }
 
@@ -42,7 +50,11 @@ object PermissionUtils {
     }
 
     private fun logDenyResult(ph: PermissionHelper, a: Activity) {
-        if (!ph.hasPhonePerm() && !ph.hasPhonePerm()) logAnalyticsEvent(a.getString(R.string.perms_basic_denied), a) else if (!ph.hasPhonePerm()) logAnalyticsEvent(a.getString(R.string.perms_phone_denied), a) else if (!ph.hasSmsPerm()) logAnalyticsEvent(a.getString(R.string.perms_sms_denied), a)
+        when {
+            !ph.hasPhonePerm() && !ph.hasSmsPerm() -> logAnalyticsEvent(a.getString(R.string.perms_basic_denied), a)
+            !ph.hasPhonePerm() -> logAnalyticsEvent(a.getString(R.string.perms_phone_denied), a)
+            !ph.hasSmsPerm() -> logAnalyticsEvent(a.getString(R.string.perms_sms_denied), a)
+        }
     }
 
     fun hasContactPermission(c: Context?): Boolean {

--- a/app/src/main/java/com/hover/stax/permissions/PermissionsActivity.kt
+++ b/app/src/main/java/com/hover/stax/permissions/PermissionsActivity.kt
@@ -7,6 +7,7 @@ import com.hover.sdk.permissions.PermissionHelper
 import android.app.Activity
 import com.hover.stax.permissions.PermissionsFragment
 import com.hover.sdk.actions.HoverAction
+import timber.log.Timber
 
 class PermissionsActivity : AppCompatActivity() {
 
@@ -15,9 +16,13 @@ class PermissionsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_permissions)
 
         if (PermissionHelper(this).hasAllPerms()) {
+            Timber.e("Has all perms, should wrap up now")
             setResult(RESULT_OK)
             finish()
-        } else showDialog()
+        } else {
+            Timber.e("Showing dialog again")
+            showDialog()
+        }
     }
 
     private fun showDialog() {

--- a/app/src/main/java/com/hover/stax/permissions/PermissionsFragment.kt
+++ b/app/src/main/java/com/hover/stax/permissions/PermissionsFragment.kt
@@ -19,14 +19,14 @@ import kotlinx.coroutines.launch
 
 class PermissionsFragment : DialogFragment() {
 
-    private var helper: PermissionHelper? = null
+    private lateinit var helper: PermissionHelper
     private var dialog: StaxPermissionDialog? = null
     private var current = 0
     private var hasLeft = false
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         helper = PermissionHelper(context)
-        current = if (helper!!.hasOverlayPerm()) ACCESS else OVERLAY
+        current = if (helper.hasOverlayPerm()) ACCESS else OVERLAY
 
         logAnalyticsEvent(getString(if (current == OVERLAY) R.string.perms_overlay_dialog else R.string.perms_accessibility_dialog), requireContext())
 
@@ -43,14 +43,14 @@ class PermissionsFragment : DialogFragment() {
     private fun requestOverlay() {
         hasLeft = true
         logAnalyticsEvent(getString(R.string.perms_overlay_requested), requireContext())
-        helper!!.requestOverlayPerm()
+        helper.requestOverlayPerm()
     }
 
     private fun requestAccessibility() {
         hasLeft = true
         logAnalyticsEvent(getString(R.string.perms_accessibility_requested), requireContext())
         Hover.setPermissionActivity(Constants.PERM_ACTIVITY, context)
-        helper!!.requestAccessPerm()
+        helper.requestAccessPerm()
     }
 
     override fun onResume() {
@@ -63,13 +63,13 @@ class PermissionsFragment : DialogFragment() {
         if (hasLeft) {
             if (current == OVERLAY) logAnalyticsEvent(
                 getString(
-                    if (helper!!.hasOverlayPerm()) R.string.perms_overlay_granted
+                    if (helper.hasOverlayPerm()) R.string.perms_overlay_granted
                     else R.string.perms_overlay_notgranted
                 ), requireContext()
             ) else if (current == ACCESS)
                 logAnalyticsEvent(
                     getString(
-                        if (helper!!.hasAccessPerm()) R.string.perms_accessibility_granted
+                        if (helper.hasAccessPerm()) R.string.perms_accessibility_granted
                         else R.string.perms_accessibility_notgranted
                     ), requireContext()
                 )
@@ -77,15 +77,16 @@ class PermissionsFragment : DialogFragment() {
     }
 
     private fun maybeUpdateToNext() {
-        if (arguments?.getInt(STARTWITH) == ACCESS && !helper!!.hasAccessPerm())
+        if (arguments?.getInt(STARTWITH) == ACCESS && !helper.hasAccessPerm())
             setOnlyNeedAccess()
-        else if (current == OVERLAY && helper!!.hasOverlayPerm() && !helper!!.hasAccessPerm())
+        else if (current == OVERLAY && helper.hasOverlayPerm() && !helper.hasAccessPerm()) {
             lifecycleScope.launch {
                 delay(500)
                 animateToStep2()
             }
-        else if (helper!!.hasAccessPerm())
+        } else if (helper.hasAccessPerm()) {
             animateToDone()
+        }
     }
 
     private fun setOnlyNeedAccess() {

--- a/app/src/main/java/com/hover/stax/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/hover/stax/settings/SettingsFragment.kt
@@ -233,7 +233,6 @@ class SettingsFragment : Fragment() {
     }
 
     private fun marketingOptIn(optedIn: Boolean) {
-        Timber.e("Opted in $optedIn")
         binding.staxSupport.contactCard.showProgressIndicator()
         loginViewModel.optInMarketing(optedIn)
 

--- a/app/src/main/res/layout/manage_permissions_layout.xml
+++ b/app/src/main/res/layout/manage_permissions_layout.xml
@@ -1,96 +1,98 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
     <com.hover.stax.views.StaxCardView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:showBack="true"
-        android:layout_marginTop="@dimen/margin_16"
-        app:subtitle="@string/manage_permission_desc"
-        app:title="@string/manage_permissions_title">
-
-        <com.google.android.material.switchmaterial.SwitchMaterial
-            android:id="@+id/calls_permission_switch"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_16"
-            android:layout_marginTop="@dimen/margin_13"
-            android:checked="false"
-            android:fontFamily="@font/brutalista_bold"
-            android:textStyle="bold"
-            android:text="@string/perm_calls_title"
-            android:textSize="@dimen/text_19" />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_16"
-            android:textColor="@color/offWhite"
-            android:text="@string/perm_calls_desc"
-            android:textSize="@dimen/text_16" />
-
-        <com.google.android.material.switchmaterial.SwitchMaterial
-            android:id="@+id/sms_permission_switch"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_16"
             android:layout_marginTop="@dimen/margin_16"
-            android:checked="false"
-            android:fontFamily="@font/brutalista_bold"
-            android:textStyle="bold"
-            android:text="@string/perm_sms_title"
-            android:textSize="@dimen/text_19" />
+            app:showBack="true"
+            app:subtitle="@string/manage_permission_desc"
+            app:title="@string/manage_permissions_title">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_16"
-            android:textColor="@color/offWhite"
-            android:text="@string/perm_sms_desc"
-            android:textSize="@dimen/text_16" />
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
-        <com.google.android.material.switchmaterial.SwitchMaterial
-            android:id="@+id/display_permission_switch"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_16"
-            android:layout_marginTop="@dimen/margin_16"
-            android:checked="false"
-            android:fontFamily="@font/brutalista_bold"
-            android:textStyle="bold"
-            android:text="@string/perm_display_title"
-            android:textSize="@dimen/text_19" />
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/calls_permission_switch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/margin_16"
+                    android:layout_marginTop="@dimen/margin_13"
+                    android:checked="false"
+                    android:fontFamily="@font/brutalista_bold"
+                    android:text="@string/perm_calls_title"
+                    android:textSize="@dimen/text_19" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_16"
-            android:textColor="@color/offWhite"
-            android:text="@string/perm_display_desc"
-            android:textSize="@dimen/text_16" />
+            <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/margin_16"
+                    android:text="@string/perm_calls_desc"
+                    android:textColor="@color/offWhite"
+                    android:textSize="@dimen/text_16" />
 
-        <com.google.android.material.switchmaterial.SwitchMaterial
-            android:id="@+id/accessibility_permission_switch"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/text_16"
-            android:layout_marginTop="@dimen/margin_16"
-            android:checked="false"
-            android:fontFamily="@font/brutalista_bold"
-            android:textStyle="bold"
-            android:text="@string/perm_accessibility_title"
-            android:textSize="@dimen/text_19" />
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/sms_permission_switch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/margin_16"
+                    android:layout_marginTop="@dimen/margin_16"
+                    android:checked="false"
+                    android:fontFamily="@font/brutalista_bold"
+                    android:text="@string/perm_sms_title"
+                    android:textSize="@dimen/text_19" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/text_16"
-            android:textColor="@color/offWhite"
-            android:text="@string/perm_accessibility_desc"
-            android:textSize="@dimen/text_16" />
+            <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/margin_16"
+                    android:text="@string/perm_sms_desc"
+                    android:textColor="@color/offWhite"
+                    android:textSize="@dimen/text_16" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/display_permission_switch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/margin_16"
+                    android:layout_marginTop="@dimen/margin_16"
+                    android:checked="false"
+                    android:fontFamily="@font/brutalista_bold"
+                    android:text="@string/perm_display_title"
+                    android:textSize="@dimen/text_19" />
+
+            <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/margin_16"
+                    android:text="@string/perm_display_desc"
+                    android:textColor="@color/offWhite"
+                    android:textSize="@dimen/text_16" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/accessibility_permission_switch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/text_16"
+                    android:layout_marginTop="@dimen/margin_16"
+                    android:checked="false"
+                    android:fontFamily="@font/brutalista_bold"
+                    android:text="@string/perm_accessibility_title"
+                    android:textSize="@dimen/text_19" />
+
+            <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/text_16"
+                    android:text="@string/perm_accessibility_desc"
+                    android:textColor="@color/offWhite"
+                    android:textSize="@dimen/text_16" />
+        </LinearLayout>
 
     </com.hover.stax.views.StaxCardView>
 

--- a/app/src/main/res/layout/settings_card_permissions.xml
+++ b/app/src/main/res/layout/settings_card_permissions.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.hover.stax.views.StaxCardView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:title="@string/app_permissions">
-
-    <TextView
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:id="@+id/permission"
-        android:layout_marginHorizontal="@dimen/margin_10"
-        android:layout_marginTop="@dimen/margin_21"
-        android:textColor="@color/offWhite"
-        android:textSize="@dimen/text_16"
-        android:background="?selectableItemBackground"
-        android:paddingVertical="@dimen/margin_13"
-        app:fontFamily="@font/brutalista_regular"
-        android:text="@string/manage_permissions_title" />
+        app:title="@string/app_permissions">
+
+    <TextView
+            android:id="@+id/permission"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin_10"
+            android:layout_marginTop="@dimen/margin_5"
+            android:background="?selectableItemBackground"
+            android:paddingVertical="@dimen/margin_13"
+            android:text="@string/manage_permissions_title"
+            android:textColor="@color/offWhite"
+            android:textSize="@dimen/text_16" />
 
 </com.hover.stax.views.StaxCardView>


### PR DESCRIPTION
This PR should fix the app flickering issue when accessibility permissions are granted in device settings. The issue was brought about by a condition that checks if `all` permissions have been granted before showing the accessibility dialog. This assumed that the `PHONE` and `SMS` permissions had already been granted at this stage. Toggling `PHONE` or `SMS` off from settings causes it to go into an endless loop.

The major change introduced here is how permissions are handled in the app settings (Stax). Here's some context from the developer docs:

_Starting in Android 11 (API level 30), if the user taps Deny for a specific permission more than once during your app's lifetime of installation on a device, the user doesn't see the system permissions dialog if your app requests that permission again. The user's action implies "don't ask again." On previous versions, users would see the system permissions dialog each time your app requested a permission, unless the user had previously selected a "don't ask again" checkbox or option. If a user denies a permission request more than once, this is considered a permanant denial._ 

Phone and SMS toggles in settings will redirect the user to device settings if the permission check comes back as either `GRANTED` or `DENIED`. Showing of the rationale is handled as well. The fallback state is requesting permissions as usual. This will work for all devices. 

We could check by device API level but that introduces complexity if we have to manage 
 - devices running Android 11 and above
 - devices below Android 11 that have selected `Dont Ask Again` in the permission dialog. 
 