### PR TITLE
Glide Intergration

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -27,7 +27,7 @@
         <entry key="app/src/main/res/drawable/ic_stax_new_logo.xml" value="0.249" />
         <entry key="app/src/main/res/drawable/ic_system_upate_24.xml" value="0.6125" />
         <entry key="app/src/main/res/drawable/ic_ussd_lib.xml" value="0.3546875" />
-        <entry key="app/src/main/res/drawable/processing_card_background.xml" value="0.241" />
+        <entry key="app/src/main/res/drawable/icon_bg_circle.xml" value="0.2295" />
         <entry key="app/src/main/res/drawable/splash_window_background.xml" value="0.2395" />
         <entry key="app/src/main/res/font/brutalista_font.xml" value="0.47265625" />
         <entry key="app/src/main/res/layout/account_card_layout.xml" value="0.25" />
@@ -153,7 +153,7 @@
         <entry key="app/src/main/res/layout/summarycard_nontemplate_items.xml" value="0.42734375" />
         <entry key="app/src/main/res/layout/support_stax_layout.xml" value="0.1646403242147923" />
         <entry key="app/src/main/res/layout/transaction_card_history.xml" value="0.19145299145299147" />
-        <entry key="app/src/main/res/layout/transaction_details_info_card.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/transaction_details_info_card.xml" value="0.22" />
         <entry key="app/src/main/res/layout/transaction_details_primarystatus.xml" value="0.20643363728470113" />
         <entry key="app/src/main/res/layout/transaction_details_secondary_status.xml" value="0.1" />
         <entry key="app/src/main/res/layout/transaction_details_topstatus_view.xml" value="0.35733695652173914" />
@@ -186,7 +186,7 @@
       </profile-state>
     </entry>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -174,6 +174,9 @@ dependencies {
     implementation 'com.appsflyer:af-android-sdk:6.2.3'
     implementation 'com.android.installreferrer:installreferrer:2.2'
 
+    implementation 'com.github.bumptech.glide:glide:4.13.0'
+    kapt 'com.github.bumptech.glide:compiler:4.13.0'
+
     def roomVersion = "2.4.2"
     implementation "androidx.room:room-ktx:$roomVersion"
     implementation "androidx.room:room-runtime:$roomVersion"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -26,3 +26,11 @@
 -keep public class com.google.firebase.messaging.FirebaseMessagingService {
   public *;
 }
+
+-keep public class * implements com.bumptech.glide.module.GlideModule
+-keep public class * extends com.bumptech.glide.module.AppGlideModule
+-keep public enum com.bumptech.glide.load.ImageHeaderParser$** {
+  **[] $VALUES;
+  public *;
+}
+-dontwarn com.bumptech.glide.load.resource.bitmap.VideoDecoder

--- a/app/src/main/java/com/hover/stax/accounts/AccountDropdown.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDropdown.kt
@@ -13,8 +13,7 @@ import com.hover.stax.R
 import com.hover.stax.channels.Channel
 import com.hover.stax.channels.ChannelsViewModel
 import com.hover.stax.utils.Constants
-import com.hover.stax.utils.Constants.size55
-import com.hover.stax.utils.GlideApp
+import com.hover.stax.utils.UIHelper
 import com.hover.stax.views.StaxDropdownLayout
 import timber.log.Timber
 
@@ -69,12 +68,7 @@ class AccountDropdown(context: Context, attributeSet: AttributeSet) : StaxDropdo
                 }
             }
 
-            GlideApp.with(context)
-                .load(account.logoUrl)
-                .placeholder(R.color.buttonColor)
-                .circleCrop()
-                .override(size55)
-                .into(target)
+            UIHelper.loadImage(context, account.logoUrl, target)
 
             if (account.name == Constants.PLACEHOLDER) {
                 accountFetchListener?.fetchAccounts(account)

--- a/app/src/main/java/com/hover/stax/accounts/AccountDropdownAdapter.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDropdownAdapter.kt
@@ -1,19 +1,13 @@
 package com.hover.stax.accounts
 
 import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
-import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory
+import com.hover.stax.R
 import com.hover.stax.databinding.StaxSpinnerItemWithLogoBinding
-import com.hover.stax.utils.Constants.size55
-import com.hover.stax.utils.UIHelper
-import com.squareup.picasso.Picasso
-import com.squareup.picasso.Target
-import timber.log.Timber
+import com.hover.stax.utils.GlideApp
 
 class AccountDropdownAdapter(val accounts: List<Account>, context: Context) : ArrayAdapter<Account>(context, 0, accounts) {
 
@@ -41,24 +35,18 @@ class AccountDropdownAdapter(val accounts: List<Account>, context: Context) : Ar
         return if (accounts.isEmpty()) null else accounts[position]
     }
 
-    inner class ViewHolder(val binding: StaxSpinnerItemWithLogoBinding) : Target {
+    inner class ViewHolder(val binding: StaxSpinnerItemWithLogoBinding) {
 
         fun setAccount(account: Account) {
             binding.serviceItemNameId.text = account.alias
-            UIHelper.loadPicasso(account.logoUrl, this)
+
+            GlideApp.with(binding.root.context)
+                .load(account.logoUrl)
+                .placeholder(R.color.buttonColor)
+                .circleCrop()
+                .into(binding.serviceItemImageId)
         }
 
-        override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
-            val d = RoundedBitmapDrawableFactory.create(binding.root.context.resources, bitmap)
-            d.isCircular = true
-            binding.serviceItemImageId.setImageDrawable(d)
-        }
-
-        override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
-            Timber.e(e)
-        }
-
-        override fun onPrepareLoad(placeHolderDrawable: Drawable?) {}
 
     }
 

--- a/app/src/main/java/com/hover/stax/accounts/AccountDropdownAdapter.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDropdownAdapter.kt
@@ -5,9 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
-import com.hover.stax.R
 import com.hover.stax.databinding.StaxSpinnerItemWithLogoBinding
-import com.hover.stax.utils.GlideApp
+import com.hover.stax.utils.UIHelper
 
 class AccountDropdownAdapter(val accounts: List<Account>, context: Context) : ArrayAdapter<Account>(context, 0, accounts) {
 
@@ -40,14 +39,8 @@ class AccountDropdownAdapter(val accounts: List<Account>, context: Context) : Ar
         fun setAccount(account: Account) {
             binding.serviceItemNameId.text = account.alias
 
-            GlideApp.with(binding.root.context)
-                .load(account.logoUrl)
-                .placeholder(R.color.buttonColor)
-                .circleCrop()
-                .into(binding.serviceItemImageId)
+            UIHelper.loadImage(binding.root.context, account.logoUrl, binding.serviceItemImageId)
         }
 
-
     }
-
 }

--- a/app/src/main/java/com/hover/stax/accounts/AccountsAdapter.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountsAdapter.kt
@@ -1,17 +1,12 @@
 package com.hover.stax.accounts
 
-import android.graphics.Bitmap
-import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory
 import androidx.recyclerview.widget.RecyclerView
+import com.hover.stax.R
 import com.hover.stax.databinding.StaxSpinnerItemWithLogoBinding
 import com.hover.stax.utils.Constants
-import com.hover.stax.utils.UIHelper
-import com.squareup.picasso.Picasso
-import com.squareup.picasso.Target
-import timber.log.Timber
+import com.hover.stax.utils.GlideApp
 
 class AccountsAdapter(val accounts: List<Account>, val selectListener: SelectListener) : RecyclerView.Adapter<AccountsAdapter.ViewHolder>() {
 
@@ -26,26 +21,20 @@ class AccountsAdapter(val accounts: List<Account>, val selectListener: SelectLis
 
     override fun getItemCount(): Int = accounts.size
 
-    inner class ViewHolder(val binding: StaxSpinnerItemWithLogoBinding) : RecyclerView.ViewHolder(binding.root), Target {
+    inner class ViewHolder(val binding: StaxSpinnerItemWithLogoBinding) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(account: Account) {
             binding.serviceItemNameId.text = account.alias
-            UIHelper.loadPicasso(account.logoUrl, Constants.size55, this)
+
+            GlideApp.with(binding.root.context)
+                .load(account.logoUrl)
+                .placeholder(R.color.buttonColor)
+                .circleCrop()
+                .override(Constants.size55)
+                .into(binding.serviceItemImageId)
 
             binding.root.setOnClickListener { selectListener.accountSelected(account) }
         }
-
-        override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
-            val d = RoundedBitmapDrawableFactory.create(binding.root.context.resources, bitmap)
-            d.isCircular = true
-            binding.serviceItemImageId.setImageDrawable(d)
-        }
-
-        override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
-            Timber.e(e)
-        }
-
-        override fun onPrepareLoad(placeHolderDrawable: Drawable?) {}
     }
 
     interface SelectListener {

--- a/app/src/main/java/com/hover/stax/actions/ActionDropdownAdapter.kt
+++ b/app/src/main/java/com/hover/stax/actions/ActionDropdownAdapter.kt
@@ -1,8 +1,6 @@
 package com.hover.stax.actions
 
 import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -10,16 +8,12 @@ import android.widget.ArrayAdapter
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory
 import com.hover.sdk.actions.HoverAction
 import com.hover.stax.R
 import com.hover.stax.accounts.Account
 import com.hover.stax.databinding.StaxSpinnerItemWithLogoBinding
 import com.hover.stax.utils.Constants
-import com.hover.stax.utils.UIHelper
-import com.squareup.picasso.Picasso
-import com.squareup.picasso.Target
-import timber.log.Timber
+import com.hover.stax.utils.GlideApp
 
 class ActionDropdownAdapter<T>(val actions: List<T>, context: Context) : ArrayAdapter<T>(context, 0, actions) {
 
@@ -47,7 +41,7 @@ class ActionDropdownAdapter<T>(val actions: List<T>, context: Context) : ArrayAd
 
     override fun getItem(position: Int): T? = if (actions.isEmpty()) null else actions[position]
 
-    class ActionViewHolder(val binding: StaxSpinnerItemWithLogoBinding) : Target {
+    class ActionViewHolder(val binding: StaxSpinnerItemWithLogoBinding) {
 
         private var id: TextView? = null
         private var logo: ImageView? = null
@@ -60,29 +54,25 @@ class ActionDropdownAdapter<T>(val actions: List<T>, context: Context) : ArrayAd
         }
 
         fun setAction(action: Any?, baseUrl: String) {
+            var logoUrl: String? = null
+
             if (action is HoverAction) {
                 id?.text = action.id.toString()
                 channelText?.text = action.toString()
-                UIHelper.loadPicasso(baseUrl.plus(action.to_institution_logo), Constants.size55, this)
+                logoUrl = baseUrl.plus(action.to_institution_logo)
             } else if (action is Account) {
                 id?.text = action.id.toString()
                 channelText?.text = action.alias
-                UIHelper.loadPicasso(baseUrl.plus(action.logoUrl), Constants.size55, this)
+                logoUrl = baseUrl.plus(action.logoUrl)
             }
-        }
 
-        override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
-            val drawable = RoundedBitmapDrawableFactory.create(id!!.context.resources, bitmap).apply { isCircular = true }
-            logo!!.setImageDrawable(drawable)
+            GlideApp.with(binding.root.context)
+                .load(logoUrl)
+                .placeholder(R.color.buttonColor)
+                .circleCrop()
+                .override(Constants.size55)
+                .into(logo!!)
         }
-
-        override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
-            Timber.e(e?.localizedMessage)
-        }
-
-        override fun onPrepareLoad(placeHolderDrawable: Drawable?) {
-        }
-
     }
 
 }

--- a/app/src/main/java/com/hover/stax/actions/ActionDropdownAdapter.kt
+++ b/app/src/main/java/com/hover/stax/actions/ActionDropdownAdapter.kt
@@ -12,8 +12,7 @@ import com.hover.sdk.actions.HoverAction
 import com.hover.stax.R
 import com.hover.stax.accounts.Account
 import com.hover.stax.databinding.StaxSpinnerItemWithLogoBinding
-import com.hover.stax.utils.Constants
-import com.hover.stax.utils.GlideApp
+import com.hover.stax.utils.UIHelper
 
 class ActionDropdownAdapter<T>(val actions: List<T>, context: Context) : ArrayAdapter<T>(context, 0, actions) {
 
@@ -66,12 +65,7 @@ class ActionDropdownAdapter<T>(val actions: List<T>, context: Context) : ArrayAd
                 logoUrl = baseUrl.plus(action.logoUrl)
             }
 
-            GlideApp.with(binding.root.context)
-                .load(logoUrl)
-                .placeholder(R.color.buttonColor)
-                .circleCrop()
-                .override(Constants.size55)
-                .into(logo!!)
+            UIHelper.loadImage(binding.root.context, logoUrl!!, logo!!)
         }
     }
 

--- a/app/src/main/java/com/hover/stax/actions/ActionSelect.kt
+++ b/app/src/main/java/com/hover/stax/actions/ActionSelect.kt
@@ -13,8 +13,7 @@ import com.bumptech.glide.request.transition.Transition
 import com.hover.sdk.actions.HoverAction
 import com.hover.stax.R
 import com.hover.stax.databinding.ActionSelectBinding
-import com.hover.stax.utils.Constants.size55
-import com.hover.stax.utils.GlideApp
+import com.hover.stax.utils.UIHelper
 import com.hover.stax.views.AbstractStatefulInput
 import timber.log.Timber
 
@@ -78,12 +77,7 @@ class ActionSelect(context: Context, attrs: AttributeSet) : LinearLayout(context
             }
         }
 
-        GlideApp.with(context)
-            .load(context.getString(R.string.root_url).plus(action.to_institution_logo))
-            .placeholder(R.color.buttonColor)
-            .circleCrop()
-            .override(size55)
-            .into(target)
+        UIHelper.loadImage(context, context.getString(R.string.root_url).plus(action.to_institution_logo), target)
 
         val options = getWhoMeOptions(action.to_institution_id)
         if (options.size == 1) selectOnlyOption(options.first())

--- a/app/src/main/java/com/hover/stax/channels/ChannelsViewHolder.kt
+++ b/app/src/main/java/com/hover/stax/channels/ChannelsViewHolder.kt
@@ -1,24 +1,18 @@
 package com.hover.stax.channels
 
-import android.graphics.Bitmap
-import android.graphics.drawable.Drawable
 import android.view.MotionEvent
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory
 import androidx.recyclerview.selection.ItemDetailsLookup
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.checkbox.MaterialCheckBox
+import com.hover.stax.R
 import com.hover.stax.databinding.StaxSpinnerItemWithLogoBinding
-import com.hover.stax.utils.Constants
-import com.hover.stax.utils.UIHelper
-import com.squareup.picasso.Picasso
-import com.squareup.picasso.Target
-import timber.log.Timber
+import com.hover.stax.utils.GlideApp
 
-class ChannelsViewHolder(val binding: StaxSpinnerItemWithLogoBinding) : RecyclerView.ViewHolder(binding.root), Target {
+class ChannelsViewHolder(val binding: StaxSpinnerItemWithLogoBinding) : RecyclerView.ViewHolder(binding.root) {
 
     var id: TextView? = null
     private var channelText: AppCompatTextView? = null
@@ -40,20 +34,12 @@ class ChannelsViewHolder(val binding: StaxSpinnerItemWithLogoBinding) : Recycler
         id!!.text = channel.id.toString()
         channelText!!.text = channel.toString()
 
-        UIHelper.loadPicasso(channel.logoUrl, Constants.size55, this)
+        GlideApp.with(binding.root.context)
+            .load(channel.logoUrl)
+            .placeholder(R.color.buttonColor)
+            .circleCrop()
+            .into(logo!!)
     }
-
-    override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
-        val d = RoundedBitmapDrawableFactory.create(id!!.context.resources, bitmap)
-        d.isCircular = true
-        logo!!.setImageDrawable(d)
-    }
-
-    override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
-        Timber.e(e)
-    }
-
-    override fun onPrepareLoad(placeHolderDrawable: Drawable?) {}
 
     fun getItemDetails(): ItemDetailsLookup.ItemDetails<Long> = object : ItemDetailsLookup.ItemDetails<Long>() {
         override fun getPosition(): Int = adapterPosition

--- a/app/src/main/java/com/hover/stax/channels/ChannelsViewHolder.kt
+++ b/app/src/main/java/com/hover/stax/channels/ChannelsViewHolder.kt
@@ -8,9 +8,8 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.recyclerview.selection.ItemDetailsLookup
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.checkbox.MaterialCheckBox
-import com.hover.stax.R
 import com.hover.stax.databinding.StaxSpinnerItemWithLogoBinding
-import com.hover.stax.utils.GlideApp
+import com.hover.stax.utils.UIHelper
 
 class ChannelsViewHolder(val binding: StaxSpinnerItemWithLogoBinding) : RecyclerView.ViewHolder(binding.root) {
 
@@ -34,11 +33,7 @@ class ChannelsViewHolder(val binding: StaxSpinnerItemWithLogoBinding) : Recycler
         id!!.text = channel.id.toString()
         channelText!!.text = channel.toString()
 
-        GlideApp.with(binding.root.context)
-            .load(channel.logoUrl)
-            .placeholder(R.color.buttonColor)
-            .circleCrop()
-            .into(logo!!)
+        UIHelper.loadImage(binding.root.context, channel.logoUrl, logo!!)
     }
 
     fun getItemDetails(): ItemDetailsLookup.ItemDetails<Long> = object : ItemDetailsLookup.ItemDetails<Long>() {

--- a/app/src/main/java/com/hover/stax/paybill/PaybillActionsAdapter.kt
+++ b/app/src/main/java/com/hover/stax/paybill/PaybillActionsAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.hover.sdk.actions.HoverAction
 import com.hover.stax.R
 import com.hover.stax.databinding.ItemPaybillActionBinding
+import com.hover.stax.utils.GlideApp
 import com.hover.stax.utils.UIHelper
 
 class PaybillActionsAdapter(private val paybillActions: List<HoverAction>, private val clickListener: PaybillActionsClickListener)
@@ -32,7 +33,11 @@ class PaybillActionsAdapter(private val paybillActions: List<HoverAction>, priva
 
             binding.root.setOnClickListener { clickListener.onSelectPaybill(action) }
 
-            UIHelper.loadPicasso(binding.billIcon.context.getString(R.string.root_url).plus(action.to_institution_logo), binding.billIcon)
+            GlideApp.with(binding.root.context)
+                .load(binding.billIcon.context.getString(R.string.root_url).plus(action.to_institution_logo))
+                .placeholder(R.color.buttonColor)
+                .circleCrop()
+                .into(binding.billIcon)
         }
     }
 

--- a/app/src/main/java/com/hover/stax/paybill/PaybillActionsAdapter.kt
+++ b/app/src/main/java/com/hover/stax/paybill/PaybillActionsAdapter.kt
@@ -6,7 +6,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.hover.sdk.actions.HoverAction
 import com.hover.stax.R
 import com.hover.stax.databinding.ItemPaybillActionBinding
-import com.hover.stax.utils.GlideApp
 import com.hover.stax.utils.UIHelper
 
 class PaybillActionsAdapter(private val paybillActions: List<HoverAction>, private val clickListener: PaybillActionsClickListener)
@@ -33,11 +32,7 @@ class PaybillActionsAdapter(private val paybillActions: List<HoverAction>, priva
 
             binding.root.setOnClickListener { clickListener.onSelectPaybill(action) }
 
-            GlideApp.with(binding.root.context)
-                .load(binding.billIcon.context.getString(R.string.root_url).plus(action.to_institution_logo))
-                .placeholder(R.color.buttonColor)
-                .circleCrop()
-                .into(binding.billIcon)
+            UIHelper.loadImage(binding.root.context, binding.billIcon.context.getString(R.string.root_url).plus(action.to_institution_logo), binding.billIcon)
         }
     }
 

--- a/app/src/main/java/com/hover/stax/paybill/PaybillAdapter.kt
+++ b/app/src/main/java/com/hover/stax/paybill/PaybillAdapter.kt
@@ -7,6 +7,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.hover.stax.R
 import com.hover.stax.databinding.ItemPaybillSavedBinding
+import com.hover.stax.utils.GlideApp
 import com.hover.stax.utils.UIHelper
 
 class PaybillAdapter(private val paybills: List<Paybill>, private val clickListener: ClickListener) : RecyclerView.Adapter<PaybillAdapter.PaybillViewHolder>() {
@@ -31,11 +32,17 @@ class PaybillAdapter(private val paybills: List<Paybill>, private val clickListe
             if (paybill.logo != 0) {
                 binding.billLogo.visibility = View.GONE
                 binding.iconLayout.visibility = View.VISIBLE
+                GlideApp.with(binding.root.context).clear(binding.billLogo)
                 binding.billIcon.setImageDrawable(ContextCompat.getDrawable(binding.billIcon.context, paybill.logo))
             } else {
                 binding.iconLayout.visibility = View.GONE
                 binding.billLogo.visibility = View.VISIBLE
-                UIHelper.loadPicasso(paybill.logoUrl, binding.billLogo)
+
+                GlideApp.with(binding.root.context)
+                    .load(paybill.logoUrl)
+                    .placeholder(R.color.buttonColor)
+                    .circleCrop()
+                    .into(binding.billLogo)
             }
 
             binding.root.setOnClickListener { clickListener.onSelectPaybill(paybill) }

--- a/app/src/main/java/com/hover/stax/paybill/PaybillAdapter.kt
+++ b/app/src/main/java/com/hover/stax/paybill/PaybillAdapter.kt
@@ -38,11 +38,7 @@ class PaybillAdapter(private val paybills: List<Paybill>, private val clickListe
                 binding.iconLayout.visibility = View.GONE
                 binding.billLogo.visibility = View.VISIBLE
 
-                GlideApp.with(binding.root.context)
-                    .load(paybill.logoUrl)
-                    .placeholder(R.color.buttonColor)
-                    .circleCrop()
-                    .into(binding.billLogo)
+                UIHelper.loadImage(binding.root.context, paybill.logoUrl, binding.billLogo)
             }
 
             binding.root.setOnClickListener { clickListener.onSelectPaybill(paybill) }

--- a/app/src/main/java/com/hover/stax/utils/StaxGlideModule.kt
+++ b/app/src/main/java/com/hover/stax/utils/StaxGlideModule.kt
@@ -1,0 +1,8 @@
+package com.hover.stax.utils
+
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+
+@GlideModule
+class StaxGlideModule : AppGlideModule() {
+}

--- a/app/src/main/java/com/hover/stax/utils/UIHelper.kt
+++ b/app/src/main/java/com/hover/stax/utils/UIHelper.kt
@@ -4,14 +4,17 @@ import android.app.Activity
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
+import android.graphics.drawable.Drawable
 import android.os.Build
 import android.text.SpannableString
 import android.text.style.UnderlineSpan
 import android.view.View
+import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.bumptech.glide.request.target.CustomTarget
 import com.google.android.material.snackbar.Snackbar
 import com.hover.stax.R
 import timber.log.Timber
@@ -30,7 +33,6 @@ object UIHelper {
         s.show()
     }
 
-    @JvmStatic
     fun flashMessage(context: Context, message: String?) {
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
     }
@@ -62,7 +64,6 @@ object UIHelper {
         }
     }
 
-
     fun setTextUnderline(textView: TextView, cs: String?) {
         val content = SpannableString(cs)
         content.setSpan(UnderlineSpan(), 0, content.length, 0)
@@ -73,4 +74,17 @@ object UIHelper {
             Timber.e(e)
         }
     }
+
+    fun loadImage(context: Context, url: String, imageView: ImageView) = GlideApp.with(context)
+        .load(url)
+        .placeholder(R.drawable.icon_bg_circle)
+        .circleCrop()
+        .into(imageView)
+
+    fun loadImage(context: Context, url: String, target: CustomTarget<Drawable>) = GlideApp.with(context)
+        .load(url)
+        .placeholder(R.drawable.icon_bg_circle)
+        .circleCrop()
+        .override(Constants.size55)
+        .into(target)
 }

--- a/app/src/main/java/com/hover/stax/utils/UIHelper.kt
+++ b/app/src/main/java/com/hover/stax/utils/UIHelper.kt
@@ -2,23 +2,18 @@ package com.hover.stax.utils
 
 import android.app.Activity
 import android.content.Context
-import android.content.res.Resources
-import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Build
 import android.text.SpannableString
 import android.text.style.UnderlineSpan
 import android.view.View
-import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.hover.stax.R
-import com.squareup.picasso.Picasso
-import com.squareup.picasso.Target
 import timber.log.Timber
 
 object UIHelper {
@@ -58,26 +53,6 @@ object UIHelper {
             ContextCompat.getColor(c!!, if (isBackground) R.color.offWhite else R.color.brightBlue)
         }
     }
-
-    fun loadPicasso(url: String?, size: Int, target: Target?) {
-        Picasso.get()
-            .load(url)
-            .config(Bitmap.Config.RGB_565)
-            .resize(size, size).into(target!!)
-    }
-
-    fun loadPicasso(url: String?, imageView: ImageView?) {
-        Picasso.get().load(url).config(Bitmap.Config.RGB_565).placeholder(R.color.buttonColor).into(imageView)
-    }
-
-    fun loadPicasso(resId: Int, size: Int, target: Target?) {
-        Picasso.get()
-            .load(resId)
-            .config(Bitmap.Config.RGB_565)
-            .resize(size, size).into(target!!)
-    }
-
-    fun loadPicasso(url: String, target: Target) = Picasso.get().load(url).config(Bitmap.Config.RGB_565).into(target)
 
     fun setFullscreenView(activity: Activity) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/app/src/main/res/layout/action_select.xml
+++ b/app/src/main/res/layout/action_select.xml
@@ -1,31 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="match_parent"
-	android:layout_height="wrap_content"
-	android:id="@+id/actionSelect"
-	android:orientation="vertical">
+        android:id="@+id/actionSelect"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
-	<com.hover.stax.views.StaxDropdownLayout
-	    android:layout_width="match_parent"
-	    android:layout_height="wrap_content"
-	    android:id="@+id/action_dropdown"
-	    android:visibility="gone"
-	    android:hint="@string/network_label" />
+    <com.hover.stax.views.StaxDropdownLayout
+            android:id="@+id/action_dropdown"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:editable="false"
+            android:hint="@string/network_label"
+            android:visibility="gone" />
 
-	<TextView
-		android:id="@+id/header"
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:layout_marginHorizontal="@dimen/margin_10"
-		android:layout_marginBottom="@dimen/margin_13"
-		android:textSize="@dimen/text_19"
-		android:text="@string/airtime_who_header"
-		android:visibility="gone"/>
+    <TextView
+            android:id="@+id/header"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin_10"
+            android:layout_marginBottom="@dimen/margin_13"
+            android:text="@string/airtime_who_header"
+            android:textSize="@dimen/text_19"
+            android:visibility="gone" />
 
-	<RadioGroup
-	    android:layout_width="match_parent"
-	    android:layout_height="wrap_content"
-	    android:layout_marginHorizontal="@dimen/margin_21"
-	    android:layout_marginBottom="@dimen/margin_21"
-	    android:id="@+id/isSelfRadio"/>
+    <RadioGroup
+            android:id="@+id/isSelfRadio"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin_21"
+            android:layout_marginBottom="@dimen/margin_21" />
 </LinearLayout>

--- a/app/src/main/res/layout/stax_dropdown.xml
+++ b/app/src/main/res/layout/stax_dropdown.xml
@@ -20,6 +20,7 @@
             android:autofillHints="phone"
             android:textCursorDrawable="@null"
             android:textSize="@dimen/text_19"
+            android:drawablePadding="@dimen/margin_8"
             app:errorTextColor="@color/stax_state_red" />
 
 </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/transfer_card_edit.xml
+++ b/app/src/main/res/layout/transfer_card_edit.xml
@@ -19,6 +19,7 @@
             android:id="@+id/accountDropdown"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:editable="false"
             android:hint="@string/account_label" />
 
     <com.hover.stax.actions.ActionSelect


### PR DESCRIPTION
- replaces Picasso with Glide to improve image loading, performance and curb leaks
- removes cursor from account dropdowns

Note: It seems the SDK is dependent on Picasso. We need to change it to use Glide then remove the dependency. 