### PR TITLE
182766412 report balance check error

### DIFF
--- a/app/src/main/java/com/hover/stax/RoutingActivity.kt
+++ b/app/src/main/java/com/hover/stax/RoutingActivity.kt
@@ -260,7 +260,7 @@ class RoutingActivity : AppCompatActivity(), BiometricChecker.AuthListener, Push
         finish()
     }
 
-    override fun onAuthError(error: String) = runOnUiThread { UIHelper.flashMessage(this, getString(R.string.toast_error_auth)) }
+    override fun onAuthError(error: String) = runOnUiThread { UIHelper.flashAndReportMessage(this, getString(R.string.toast_error_auth)) }
 
     override fun onAuthSuccess(action: HoverAction?) = chooseNavigation(intent)
 

--- a/app/src/main/java/com/hover/stax/accounts/AccountDetailFragment.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDetailFragment.kt
@@ -211,7 +211,7 @@ class AccountDetailFragment : Fragment(), TransactionHistoryAdapter.SelectListen
     private fun removeAccount(account: Account) {
         viewModel.removeAccount(account)
         NavHostFragment.findNavController(this).popBackStack()
-        UIHelper.flashMessage(requireActivity(), resources.getString(R.string.toast_confirm_acctremoved))
+        UIHelper.flashAndReportMessage(requireActivity(), resources.getString(R.string.toast_confirm_acctremoved))
     }
 
     private fun initRecyclerViews() {

--- a/app/src/main/java/com/hover/stax/home/MainActivity.kt
+++ b/app/src/main/java/com/hover/stax/home/MainActivity.kt
@@ -117,7 +117,7 @@ class MainActivity : AbstractGoogleAuthActivity(), BiometricChecker.AuthListener
             sendSms(requestViewModel, this)
         } else if (requestCode == SMS) {
             AnalyticsUtil.logAnalyticsEvent(getString(R.string.perms_sms_denied), this)
-            UIHelper.flashMessage(this, getString(R.string.toast_error_smsperm))
+            UIHelper.flashAndReportMessage(this, getString(R.string.toast_error_smsperm))
         }
     }
 

--- a/app/src/main/java/com/hover/stax/hover/AbstractHoverCallerActivity.kt
+++ b/app/src/main/java/com/hover/stax/hover/AbstractHoverCallerActivity.kt
@@ -104,7 +104,7 @@ abstract class AbstractHoverCallerActivity : AppCompatActivity(), PushNotificati
         else ""
     }
 
-    private fun showMessage(str: String) = UIHelper.flashMessage(this, findViewById(R.id.fab), str)
+    private fun showMessage(str: String) = UIHelper.showAndReportSnackBar(this, findViewById(R.id.fab), str)
 
     private fun showBountyDetails(data: Intent?) {
         Timber.i("Request code is bounty")

--- a/app/src/main/java/com/hover/stax/hover/AbstractHoverCallerActivity.kt
+++ b/app/src/main/java/com/hover/stax/hover/AbstractHoverCallerActivity.kt
@@ -41,7 +41,7 @@ abstract class AbstractHoverCallerActivity : AppCompatActivity(), PushNotificati
         hsb.run()
         updatePushNotifGroupStatus()
     } catch (e: Exception) {
-        runOnUiThread { UIHelper.flashMessage(this, getString(R.string.error_running_action)) }
+        runOnUiThread { UIHelper.flashAndReportMessage(this, getString(R.string.error_running_action)) }
         createLog(hsb, "Failed Actions")
     }
 

--- a/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
+++ b/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
@@ -137,7 +137,7 @@ abstract class AbstractGoogleAuthActivity : AbstractHoverCallerActivity(), StaxG
     }
 
     override fun googleLoginFailed() {
-        UIHelper.flashMessage(this, R.string.login_google_err)
+        UIHelper.flashAndReportMessage(this, R.string.login_google_err)
     }
 
     companion object {

--- a/app/src/main/java/com/hover/stax/paybill/PaybillFragment.kt
+++ b/app/src/main/java/com/hover/stax/paybill/PaybillFragment.kt
@@ -120,7 +120,7 @@ class PaybillFragment : AbstractFormFragment(), PaybillIconsAdapter.IconSelectLi
             viewModel.selectedPaybill.value?.isSaved == true -> viewModel.setEditing(false)
             else -> {
                 viewModel.savePaybill(accountsViewModel.activeAccount.value, actionSelectViewModel.activeAction.value)
-                UIHelper.flashMessage(requireActivity(), R.string.paybill_save_success)
+                UIHelper.flashAndReportMessage(requireActivity(), R.string.paybill_save_success)
             }
         }
     }
@@ -295,7 +295,7 @@ class PaybillFragment : AbstractFormFragment(), PaybillIconsAdapter.IconSelectLi
             .setPosButton(R.string.btn_update) { _ ->
                 if (activity != null) {
                     viewModel.updatePaybill(it)
-                    UIHelper.flashMessage(requireActivity(), R.string.paybill_update_success)
+                    UIHelper.flashAndReportMessage(requireActivity(), R.string.paybill_update_success)
                     viewModel.setEditing(false)
                 }
             }

--- a/app/src/main/java/com/hover/stax/paybill/PaybillListFragment.kt
+++ b/app/src/main/java/com/hover/stax/paybill/PaybillListFragment.kt
@@ -108,7 +108,7 @@ class PaybillListFragment : Fragment(), PaybillAdapter.ClickListener, PaybillAct
             .setPosButton(R.string.btn_delete) {
                 if (activity != null) {
                     paybillViewModel.deletePaybill(paybill)
-                    UIHelper.flashMessage(requireActivity(), R.string.paybill_delete_success)
+                    UIHelper.flashAndReportMessage(requireActivity(), R.string.paybill_delete_success)
                 }
             }
         dialog!!.showIt()

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeFragment.kt
@@ -95,7 +95,7 @@ class HomeFragment : Fragment(), FinancialTipClickInterface, BalanceTapListener 
         }
 
         collectLifecycleFlow(balancesViewModel.actionRunError) {
-            UIHelper.flashMessage(requireActivity(), it)
+            UIHelper.flashMessage(requireActivity(), it, isAppError = true)
         }
     }
 

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeFragment.kt
@@ -95,7 +95,7 @@ class HomeFragment : Fragment(), FinancialTipClickInterface, BalanceTapListener 
         }
 
         collectLifecycleFlow(balancesViewModel.actionRunError) {
-            UIHelper.flashMessage(requireActivity(), it, isAppError = true)
+            UIHelper.flashAndReportError(requireActivity(), it)
         }
     }
 

--- a/app/src/main/java/com/hover/stax/requests/RequestDetailFragment.kt
+++ b/app/src/main/java/com/hover/stax/requests/RequestDetailFragment.kt
@@ -14,7 +14,6 @@ import com.hover.stax.databinding.FragmentRequestDetailBinding
 import com.hover.stax.utils.AnalyticsUtil.logAnalyticsEvent
 import com.hover.stax.utils.DateUtils
 import com.hover.stax.utils.UIHelper.flashAndReportMessage
-import com.hover.stax.utils.UIHelper.flashMessage
 import com.hover.stax.utils.Utils
 import com.hover.stax.views.Stax2LineItem
 import com.hover.stax.views.StaxDialog

--- a/app/src/main/java/com/hover/stax/requests/RequestDetailFragment.kt
+++ b/app/src/main/java/com/hover/stax/requests/RequestDetailFragment.kt
@@ -13,6 +13,7 @@ import com.hover.stax.contacts.StaxContact
 import com.hover.stax.databinding.FragmentRequestDetailBinding
 import com.hover.stax.utils.AnalyticsUtil.logAnalyticsEvent
 import com.hover.stax.utils.DateUtils
+import com.hover.stax.utils.UIHelper.flashAndReportMessage
 import com.hover.stax.utils.UIHelper.flashMessage
 import com.hover.stax.utils.Utils
 import com.hover.stax.views.Stax2LineItem
@@ -98,7 +99,7 @@ class RequestDetailFragment: Fragment(), RequestSenderInterface  {
                 .setNegButton(R.string.btn_back) {}
                 .setPosButton(R.string.btn_cancelreq) {
                     viewModel.deleteRequest()
-                    flashMessage(requireActivity(), getString(R.string.toast_confirm_cancelreq))
+                    flashAndReportMessage(requireActivity(), getString(R.string.toast_confirm_cancelreq))
                     NavHostFragment.findNavController(this@RequestDetailFragment).popBackStack()
                 }
                 .isDestructive

--- a/app/src/main/java/com/hover/stax/requests/RequestSenderInterface.kt
+++ b/app/src/main/java/com/hover/stax/requests/RequestSenderInterface.kt
@@ -15,7 +15,6 @@ import com.hover.stax.domain.model.Account
 import com.hover.stax.contacts.StaxContact
 import com.hover.stax.utils.AnalyticsUtil.logAnalyticsEvent
 import com.hover.stax.utils.UIHelper.flashAndReportMessage
-import com.hover.stax.utils.UIHelper.flashMessage
 import com.hover.stax.utils.Utils.copyToClipboard
 
 const val REQUEST_LINK = "request_link"

--- a/app/src/main/java/com/hover/stax/requests/RequestSenderInterface.kt
+++ b/app/src/main/java/com/hover/stax/requests/RequestSenderInterface.kt
@@ -14,6 +14,7 @@ import com.hover.stax.R
 import com.hover.stax.domain.model.Account
 import com.hover.stax.contacts.StaxContact
 import com.hover.stax.utils.AnalyticsUtil.logAnalyticsEvent
+import com.hover.stax.utils.UIHelper.flashAndReportMessage
 import com.hover.stax.utils.UIHelper.flashMessage
 import com.hover.stax.utils.Utils.copyToClipboard
 
@@ -112,6 +113,6 @@ interface RequestSenderInterface : SmsSentObserver.SmsSentListener {
     }
 
     fun showError(c: Context) {
-        flashMessage(c, c.getString(R.string.loading_link_dialoghead))
+        flashAndReportMessage(c, c.getString(R.string.loading_link_dialoghead))
     }
 }

--- a/app/src/main/java/com/hover/stax/schedules/ScheduleDetailFragment.kt
+++ b/app/src/main/java/com/hover/stax/schedules/ScheduleDetailFragment.kt
@@ -104,7 +104,7 @@ class ScheduleDetailFragment : Fragment() {
                 .setNegButton(R.string.btn_back) {}
                 .setPosButton(R.string.btn_canceltrans) {
                     viewModel.deleteSchedule()
-                    UIHelper.flashMessage(requireActivity(), getString(R.string.toast_confirm_cancelfuture))
+                    UIHelper.flashAndReportMessage(requireActivity(), getString(R.string.toast_confirm_cancelfuture))
                     findNavController().popBackStack()
                 }
                 .isDestructive
@@ -119,7 +119,7 @@ class ScheduleDetailFragment : Fragment() {
                         ScheduleWorker.makeWork()).enqueue()
 
                 if (!schedule.isScheduledForToday)
-                    UIHelper.flashMessage(requireActivity(), "Shouldn't show notification; not scheduled for today")
+                    UIHelper.flashAndReportMessage(requireActivity(), "Shouldn't show notification; not scheduled for today")
             }
         }
     }

--- a/app/src/main/java/com/hover/stax/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/hover/stax/settings/SettingsFragment.kt
@@ -70,7 +70,7 @@ class SettingsFragment : Fragment() {
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                accountsViewModel.accountUpdateMsg.collect { UIHelper.flashMessage(requireActivity(), it) }
+                accountsViewModel.accountUpdateMsg.collect { UIHelper.flashAndReportMessage(requireActivity(), it) }
             }
         }
     }
@@ -188,19 +188,19 @@ class SettingsFragment : Fragment() {
     private fun setUpEnableTestMode() {
         binding.settingsCard.testMode.setOnCheckedChangeListener { _, isChecked ->
             Utils.saveBoolean(TEST_MODE, isChecked, requireContext())
-            UIHelper.flashMessage(requireContext(), if (isChecked) R.string.test_mode_toast else R.string.test_mode_disabled)
+            UIHelper.flashAndReportMessage(requireContext(), if (isChecked) R.string.test_mode_toast else R.string.test_mode_disabled)
         }
         binding.settingsCard.testMode.visibility = if (Utils.getBoolean(TEST_MODE, requireContext())) VISIBLE else GONE
         binding.disclaimer.setOnClickListener {
             clickCounter++
-            if (clickCounter == 5) UIHelper.flashMessage(requireContext(), R.string.test_mode_almost_toast) else if (clickCounter == 7) enableTestMode()
+            if (clickCounter == 5) UIHelper.flashAndReportMessage(requireContext(), R.string.test_mode_almost_toast) else if (clickCounter == 7) enableTestMode()
         }
     }
 
     private fun enableTestMode() {
         Utils.saveBoolean(TEST_MODE, true, requireActivity())
         binding.settingsCard.testMode.visibility = VISIBLE
-        UIHelper.flashMessage(requireContext(), R.string.test_mode_toast)
+        UIHelper.flashAndReportMessage(requireContext(), R.string.test_mode_toast)
     }
 
     private fun startBounties() {
@@ -225,7 +225,7 @@ class SettingsFragment : Fragment() {
     private fun logoutUser() {
         loginViewModel.silentSignOut()
         binding.staxSupport.marketingOptIn.isChecked = false
-        UIHelper.flashMessage(requireActivity(), getString(R.string.logout_out_success))
+        UIHelper.flashAndReportMessage(requireActivity(), getString(R.string.logout_out_success))
     }
 
     private fun showLoginDialog() {

--- a/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsFragment.kt
+++ b/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsFragment.kt
@@ -241,7 +241,7 @@ class TransactionDetailsFragment : Fragment() {
 
     private fun maybeRetry(transaction: StaxTransaction) {
         if (viewModel.account.value == null || viewModel.action.value == null || viewModel.transaction.value == null)
-            UIHelper.flashMessage(requireContext(), getString(R.string.error_still_loading))
+            UIHelper.flashMessage(requireContext(), getString(R.string.error_still_loading), isAppError = true)
         else {
             retry(transaction)
         }

--- a/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsFragment.kt
+++ b/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsFragment.kt
@@ -241,7 +241,7 @@ class TransactionDetailsFragment : Fragment() {
 
     private fun maybeRetry(transaction: StaxTransaction) {
         if (viewModel.account.value == null || viewModel.action.value == null || viewModel.transaction.value == null)
-            UIHelper.flashMessage(requireContext(), getString(R.string.error_still_loading), isAppError = true)
+            UIHelper.flashAndReportError(requireContext(), R.string.error_still_loading)
         else {
             retry(transaction)
         }

--- a/app/src/main/java/com/hover/stax/transfers/AbstractFormFragment.kt
+++ b/app/src/main/java/com/hover/stax/transfers/AbstractFormFragment.kt
@@ -104,7 +104,7 @@ abstract class AbstractFormFragment : Fragment() {
             } else {
                 onSubmitForm()
             }
-        } else UIHelper.flashMessage(requireActivity(), getString(R.string.toast_pleasefix))
+        } else UIHelper.flashAndReportMessage(requireActivity(), getString(R.string.toast_pleasefix))
     }
 
     abstract fun validates(): Boolean
@@ -174,7 +174,7 @@ abstract class AbstractFormFragment : Fragment() {
 
     private fun showError(userMsg: Int, logMsg: Int) {
         log(getString(logMsg))
-        UIHelper.flashMessage(requireContext(), getString(userMsg))
+        UIHelper.flashAndReportMessage(requireContext(), getString(userMsg))
     }
 
     abstract fun onContactSelected(contact: StaxContact)

--- a/app/src/main/java/com/hover/stax/utils/UIHelper.kt
+++ b/app/src/main/java/com/hover/stax/utils/UIHelper.kt
@@ -34,7 +34,7 @@ object UIHelper {
 
     private const val INITIAL_ITEMS_FETCH = 30
 
-    fun flashMessage(context: Context, view: View?, message: String?) {
+    fun flashMessage(context: Context, view: View?, message: String) {
         if (view == null) flashMessage(context, message) else showSnack(view, message)
     }
 
@@ -44,12 +44,17 @@ object UIHelper {
         s.show()
     }
 
-    fun flashMessage(context: Context, message: String?) {
+    fun flashMessage(context: Context, message: String, isAppError: Boolean = false) {
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        AnalyticsUtil.logAnalyticsEvent(message, context)
+        if(isAppError) AnalyticsUtil.logErrorAndReportToFirebase(context.getString(R.string.toast_err_tag), message, null)
     }
 
-    fun flashMessage(context: Context, messageRes: Int) {
-        Toast.makeText(context, context.getString(messageRes), Toast.LENGTH_SHORT).show()
+    fun flashMessage(context: Context, messageRes: Int, isAppError: Boolean = false) {
+        val message = context.getString(messageRes)
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        AnalyticsUtil.logAnalyticsEvent(message, context)
+        if(isAppError) AnalyticsUtil.logErrorAndReportToFirebase(context.getString(R.string.toast_err_tag), message, null)
     }
 
     fun setMainLinearManagers(context: Context?): LinearLayoutManager {

--- a/app/src/main/java/com/hover/stax/utils/UIHelper.kt
+++ b/app/src/main/java/com/hover/stax/utils/UIHelper.kt
@@ -34,7 +34,7 @@ object UIHelper {
 
     private const val INITIAL_ITEMS_FETCH = 30
 
-    fun flashMessage(context: Context, view: View?, message: String) {
+    fun showAndReportSnackBar(context: Context, view: View?, message: String) {
         if (view == null) flashAndReportMessage(context, message) else showSnack(view, message)
     }
 

--- a/app/src/main/java/com/hover/stax/utils/UIHelper.kt
+++ b/app/src/main/java/com/hover/stax/utils/UIHelper.kt
@@ -35,26 +35,34 @@ object UIHelper {
     private const val INITIAL_ITEMS_FETCH = 30
 
     fun flashMessage(context: Context, view: View?, message: String) {
-        if (view == null) flashMessage(context, message) else showSnack(view, message)
+        if (view == null) flashAndReportMessage(context, message) else showSnack(view, message)
     }
 
     private fun showSnack(view: View, message: String?) {
         val s = Snackbar.make(view, message!!, Snackbar.LENGTH_LONG)
         s.anchorView = view
         s.show()
+        AnalyticsUtil.logAnalyticsEvent(message, view.context)
     }
 
-    fun flashMessage(context: Context, message: String, isAppError: Boolean = false) {
+    fun flashAndReportMessage(context: Context, messageRes: Int) {
+        flashAndReportMessage(context, context.getString(messageRes))
+    }
+
+    fun flashAndReportMessage(context: Context, message: String) {
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         AnalyticsUtil.logAnalyticsEvent(message, context)
-        if(isAppError) AnalyticsUtil.logErrorAndReportToFirebase(context.getString(R.string.toast_err_tag), message, null)
     }
 
-    fun flashMessage(context: Context, messageRes: Int, isAppError: Boolean = false) {
+    fun flashAndReportError(context: Context, messageRes: Int) {
         val message = context.getString(messageRes)
+        flashAndReportError(context, message)
+    }
+
+    fun flashAndReportError(context: Context, message: String) {
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         AnalyticsUtil.logAnalyticsEvent(message, context)
-        if(isAppError) AnalyticsUtil.logErrorAndReportToFirebase(context.getString(R.string.toast_err_tag), message, null)
+        AnalyticsUtil.logErrorAndReportToFirebase(context.getString(R.string.toast_err_tag), message, null)
     }
 
     fun setMainLinearManagers(context: Context?): LinearLayoutManager {

--- a/app/src/main/java/com/hover/stax/utils/Utils.kt
+++ b/app/src/main/java/com/hover/stax/utils/Utils.kt
@@ -154,7 +154,7 @@ object Utils {
         val clip = ClipData.newPlainText("Stax content", content)
         if (clipboard != null) {
             clipboard.setPrimaryClip(clip)
-            UIHelper.flashMessage(c, c.getString(R.string.copied))
+            UIHelper.flashAndReportMessage(c, c.getString(R.string.copied))
             return true
         }
         return false
@@ -199,7 +199,7 @@ object Utils {
             context.startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             Timber.e("Activity not found")
-            UIHelper.flashMessage(context, context.getString(R.string.email_client_not_found))
+            UIHelper.flashAndReportMessage(context, context.getString(R.string.email_client_not_found))
         }
     }
 
@@ -241,6 +241,6 @@ object Utils {
         if (PermissionUtils.has(arrayOf(Manifest.permission.CALL_PHONE), c))
             c.startActivity(dialIntent)
         else
-            UIHelper.flashMessage(c, c.getString(R.string.enable_call_permission))
+            UIHelper.flashAndReportMessage(c, c.getString(R.string.enable_call_permission))
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -713,6 +713,7 @@
     <string name="ussd_lib">Dial USSD</string>
 
     <string name="error_running_action">Sorry, this service integration is broken.</string>
+    <string name="toast_err_tag">toast_err_notif</string>
     <string name="error_still_loading">Please wait a moment and try again.</string>
 
     <!-- Financial Tips -->


### PR DESCRIPTION
- Updated naming to: flashAndReportMessage and flashAndReportError.
- Make all toast logged to analytics.
- Log toast error notifications to Crashlytics.