### PR TITLE
Rewording get_rewarded text value

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -753,7 +753,7 @@
     <string name="login_dialog_desc">Please sign in to Stax with Google to be able to receive marketing updates.</string>
     <string name="update_downloaded">An update has just been downloaded.</string>
     <string name="restart">Restart</string>
-    <string name="get_rewarded">Get Rewarded</string>
+    <string name="get_rewarded">Get Airtime Bonus</string>
 
     <!-- Bonus airtime -->
     <string name="bonus_airtime_applied">Bonus airtime will be applied.</string>


### PR DESCRIPTION
Rewording text value for get_rewarded from "Get Rewarded" to "Get Airtime Bonus". This is a more nudging CTA.