### PR TITLE
Adds support for multiple placeholder accounts

### DIFF
--- a/app/src/main/java/com/hover/stax/accounts/AccountDetailFragment.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDetailFragment.kt
@@ -145,7 +145,7 @@ class AccountDetailFragment : Fragment(), TransactionHistoryAdapter.SelectListen
                     } else binding.balanceCard.balanceSubtitle.text = getString(R.string.refresh_balance_desc)
 
                     binding.feesDescription.text = getString(R.string.fees_label, acct.name)
-                    binding.detailsCard.officialName.text = if(acct.name == PLACEHOLDER) acct.alias else acct.name
+                    binding.detailsCard.officialName.text = if(acct.name.contains(PLACEHOLDER)) acct.alias else acct.name
 
                     binding.manageCard.nicknameInput.setText(acct.alias, false)
                     binding.manageCard.accountNumberInput.setText(acct.accountNo, false)

--- a/app/src/main/java/com/hover/stax/accounts/AccountsViewModel.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountsViewModel.kt
@@ -121,7 +121,7 @@ class AccountsViewModel(application: Application, val repo: AccountRepo, val act
         }
     }
 
-    fun isValidAccount(): Boolean = activeAccount.value!!.name != PLACEHOLDER
+    fun isValidAccount(): Boolean = !activeAccount.value!!.name.contains(PLACEHOLDER)
 
     fun view(s: Schedule) {
         setType(s.type)

--- a/app/src/main/java/com/hover/stax/addChannels/AddChannelsFragment.kt
+++ b/app/src/main/java/com/hover/stax/addChannels/AddChannelsFragment.kt
@@ -120,10 +120,6 @@ class AddChannelsFragment : Fragment(), ChannelsAdapter.SelectListener, CountryA
     }
 
     private fun fillUpChannelLists() {
-        binding.selectedList.apply {
-            layoutManager = UIHelper.setMainLinearManagers(requireContext())
-        }
-
         binding.channelsList.apply {
             layoutManager = UIHelper.setMainLinearManagers(requireContext())
             adapter = selectAdapter
@@ -175,12 +171,12 @@ class AddChannelsFragment : Fragment(), ChannelsAdapter.SelectListener, CountryA
         binding.channelsListCard.hideProgressIndicator()
 
         showSelected(accounts.isNotEmpty())
-        if (accounts.isNotEmpty())
-            binding.selectedList.adapter = AccountsAdapter(accounts)
+//        if (accounts.isNotEmpty())
+//            binding.selectedList.adapter = AccountsAdapter(accounts)
     }
 
     private fun showSelected(visible: Boolean) {
-        binding.selectedChannelsCard.visibility = if (visible) VISIBLE else GONE
+//        binding.selectedChannelsCard.visibility = if (visible) VISIBLE else GONE
         binding.channelsListCard.setBackButtonVisibility(if (visible) GONE else VISIBLE)
     }
 

--- a/app/src/main/java/com/hover/stax/data/local/channels/ChannelDao.kt
+++ b/app/src/main/java/com/hover/stax/data/local/channels/ChannelDao.kt
@@ -69,4 +69,5 @@ interface ChannelDao {
 
     @Query("DELETE FROM channels")
     fun deleteAll()
+
 }

--- a/app/src/main/java/com/hover/stax/data/repository/AccountRepositoryImpl.kt
+++ b/app/src/main/java/com/hover/stax/data/repository/AccountRepositoryImpl.kt
@@ -32,7 +32,7 @@ class AccountRepositoryImpl(val accountRepo: AccountRepo, val channelRepo: Chann
         val defaultAccount = accountRepo.getDefaultAccountAsync()
 
         val accounts = channels.mapIndexed { index, channel ->
-            val accountName: String = if (getFetchAccountAction(channel.id) == null) channel.name else PLACEHOLDER //placeholder alias for easier identification later
+            val accountName: String = if (getFetchAccountAction(channel.id) == null) channel.name else channel.name.plus(PLACEHOLDER )//placeholder alias for easier identification later
             Account(
                 accountName, channel.name, channel.logoUrl, channel.accountNo, channel.id, channel.countryAlpha2,
                 channel.id, channel.primaryColorHex, channel.secondaryColorHex, defaultAccount == null && index == 0

--- a/app/src/main/java/com/hover/stax/domain/model/Account.kt
+++ b/app/src/main/java/com/hover/stax/domain/model/Account.kt
@@ -5,7 +5,7 @@ import com.hover.stax.channels.Channel
 import com.hover.stax.utils.DateUtils.now
 import timber.log.Timber
 
-const val PLACEHOLDER = "placeholder"
+const val PLACEHOLDER = " placeholder"
 const val ACCOUNT_NAME: String = "account_name"
 const val ACCOUNT_ID: String = "account_id"
 

--- a/app/src/main/java/com/hover/stax/hover/TransactionReceiver.kt
+++ b/app/src/main/java/com/hover/stax/hover/TransactionReceiver.kt
@@ -196,7 +196,7 @@ class TransactionReceiver : BroadcastReceiver(), KoinComponent {
         parsedAccounts.forEach {
             if (savedAccounts.contains(it.channelId)) {
                 Timber.e("Removing ${it.channelId} from ${it.name}")
-                accountRepo.deleteAccount(it.channelId, PLACEHOLDER)
+                accountRepo.deleteAccount(it.channelId, it.name.plus(PLACEHOLDER))
             }
         }
     }

--- a/app/src/main/java/com/hover/stax/presentation/home/BalancesViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/BalancesViewModel.kt
@@ -44,8 +44,10 @@ class BalancesViewModel(application: Application, val actionRepo: ActionRepo, va
     }
 
     private fun startBalanceActionFor(account: Account?) = viewModelScope.launch(Dispatchers.IO) {
-        val channelId = account?.channelId ?: -1
-        val action = actionRepo.getActions(channelId, if (account?.name == PLACEHOLDER) HoverAction.FETCH_ACCOUNTS else HoverAction.BALANCE).firstOrNull()
+        if(account == null) return@launch
+
+        val channelId = account.channelId
+        val action = actionRepo.getActions(channelId, if (account.name.contains(PLACEHOLDER)) HoverAction.FETCH_ACCOUNTS else HoverAction.BALANCE).firstOrNull()
         action?.let { _balanceAction.emit(action) } ?: run { _actionRunError.send((getApplication() as Context).getString(R.string.error_running_action)) }
     }
 

--- a/app/src/main/java/com/hover/stax/requests/NewRequestViewModel.kt
+++ b/app/src/main/java/com/hover/stax/requests/NewRequestViewModel.kt
@@ -69,7 +69,7 @@ class NewRequestViewModel(application: Application, val repo: RequestRepo, val a
 
     fun accountError(): String? = if (activeAccount.value != null) null else getString(R.string.accounts_error_noselect)
 
-    fun isValidAccount(): Boolean = activeAccount.value!!.name != PLACEHOLDER
+    fun isValidAccount(): Boolean = !activeAccount.value!!.name.contains(PLACEHOLDER)
 
     fun requesterAcctNoError(): String? = if (!requesterNumber.value.isNullOrEmpty()) null else getString(R.string.requester_number_fielderror)
 

--- a/app/src/main/res/layout/fragment_add_channels.xml
+++ b/app/src/main/res/layout/fragment_add_channels.xml
@@ -14,26 +14,26 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-        <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical">
+<!--        <LinearLayout-->
+<!--                android:layout_width="match_parent"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:orientation="vertical">-->
 
-            <com.hover.stax.views.StaxCardView
-                    android:id="@+id/selectedChannels_card"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:defaultBackPress="true"
-                    app:showBack="true"
-                    app:title="@string/your_accounts">
+<!--            <com.hover.stax.views.StaxCardView-->
+<!--                    android:id="@+id/selectedChannels_card"-->
+<!--                    android:layout_width="match_parent"-->
+<!--                    android:layout_height="wrap_content"-->
+<!--                    app:defaultBackPress="true"-->
+<!--                    app:showBack="true"-->
+<!--                    app:title="@string/your_accounts">-->
 
-                <androidx.recyclerview.widget.RecyclerView
-                        android:id="@+id/selectedList"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:nestedScrollingEnabled="false"/>
+<!--                <androidx.recyclerview.widget.RecyclerView-->
+<!--                        android:id="@+id/selectedList"-->
+<!--                        android:layout_width="match_parent"-->
+<!--                        android:layout_height="wrap_content"-->
+<!--                        android:nestedScrollingEnabled="false"/>-->
 
-            </com.hover.stax.views.StaxCardView>
+<!--            </com.hover.stax.views.StaxCardView>-->
 
             <com.hover.stax.views.StaxCardView
                     android:id="@+id/channels_list_card"
@@ -87,7 +87,7 @@
 
             </com.hover.stax.views.StaxCardView>
 
-        </LinearLayout>
+<!--        </LinearLayout>-->
     </androidx.core.widget.NestedScrollView>
 
     <Button

--- a/app/src/main/res/layout/fragment_add_channels.xml
+++ b/app/src/main/res/layout/fragment_add_channels.xml
@@ -14,27 +14,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-<!--        <LinearLayout-->
-<!--                android:layout_width="match_parent"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:orientation="vertical">-->
-
-<!--            <com.hover.stax.views.StaxCardView-->
-<!--                    android:id="@+id/selectedChannels_card"-->
-<!--                    android:layout_width="match_parent"-->
-<!--                    android:layout_height="wrap_content"-->
-<!--                    app:defaultBackPress="true"-->
-<!--                    app:showBack="true"-->
-<!--                    app:title="@string/your_accounts">-->
-
-<!--                <androidx.recyclerview.widget.RecyclerView-->
-<!--                        android:id="@+id/selectedList"-->
-<!--                        android:layout_width="match_parent"-->
-<!--                        android:layout_height="wrap_content"-->
-<!--                        android:nestedScrollingEnabled="false"/>-->
-
-<!--            </com.hover.stax.views.StaxCardView>-->
-
             <com.hover.stax.views.StaxCardView
                     android:id="@+id/channels_list_card"
                     android:layout_width="match_parent"
@@ -87,7 +66,6 @@
 
             </com.hover.stax.views.StaxCardView>
 
-<!--        </LinearLayout>-->
     </androidx.core.widget.NestedScrollView>
 
     <Button


### PR DESCRIPTION
- Changes account placeholder naming to account for name uniqueness constraint in db. `Name` field in `Account` model is unique but since we name all placeholders the same, the room query would ignore any inserts. 
- Removes my accounts from add channels fragment.