### PR TITLE
182744774 make financial tips dismissible from homescreen

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Stax" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/app/src/main/java/com/hover/stax/data/repository/FinancialTipsRepositoryImpl.kt
+++ b/app/src/main/java/com/hover/stax/data/repository/FinancialTipsRepositoryImpl.kt
@@ -6,8 +6,10 @@ import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.firestore.ktx.firestoreSettings
 import com.google.firebase.ktx.Firebase
 import com.hover.stax.R
+import com.hover.stax.domain.model.FINANCIAL_TIP_ID
 import com.hover.stax.domain.model.FinancialTip
 import com.hover.stax.domain.repository.FinancialTipsRepository
+import com.hover.stax.utils.Utils
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.tasks.await
@@ -34,5 +36,13 @@ class FinancialTipsRepositoryImpl(val context: Context) : FinancialTipsRepositor
                     document.data!!["deep link"].toString()
                 )
             }
+    }
+
+    override fun getDismissedTipId(): String? {
+        return Utils.getString(FINANCIAL_TIP_ID, context)
+    }
+
+    override fun dismissTip(id: String) {
+        Utils.saveString(FINANCIAL_TIP_ID, id, context)
     }
 }

--- a/app/src/main/java/com/hover/stax/di/Modules.kt
+++ b/app/src/main/java/com/hover/stax/di/Modules.kt
@@ -22,7 +22,7 @@ import com.hover.stax.domain.use_case.bonus.FetchBonusUseCase
 import com.hover.stax.domain.use_case.bonus.GetBonusesUseCase
 import com.hover.stax.domain.use_case.bounties.GetChannelBountiesUseCase
 import com.hover.stax.domain.use_case.channels.GetPresentSimsUseCase
-import com.hover.stax.domain.use_case.financial_tips.GetTipsUseCase
+import com.hover.stax.domain.use_case.financial_tips.TipsUseCase
 import com.hover.stax.faq.FaqViewModel
 import com.hover.stax.futureTransactions.FutureViewModel
 import com.hover.stax.inapp_banner.BannerViewModel
@@ -124,7 +124,7 @@ val useCases = module {
     factoryOf(::SetDefaultAccountUseCase)
     factoryOf(::CreateAccountsUseCase)
 
-    factoryOf(::GetTipsUseCase)
+    factoryOf(::TipsUseCase)
 
     factoryOf(::GetChannelBountiesUseCase)
     factoryOf(::GetPresentSimsUseCase)

--- a/app/src/main/java/com/hover/stax/domain/model/FinancialTip.kt
+++ b/app/src/main/java/com/hover/stax/domain/model/FinancialTip.kt
@@ -9,3 +9,4 @@ data class FinancialTip(
     val shareCopy: String?,
     val deepLink: String?
 )
+val FINANCIAL_TIP_ID = "id"

--- a/app/src/main/java/com/hover/stax/domain/repository/FinancialTipsRepository.kt
+++ b/app/src/main/java/com/hover/stax/domain/repository/FinancialTipsRepository.kt
@@ -6,4 +6,6 @@ import kotlinx.coroutines.flow.Flow
 interface FinancialTipsRepository {
 
     suspend fun getTips(): List<FinancialTip>
+    fun getDismissedTipId() : String?
+    fun dismissTip(id: String)
 }

--- a/app/src/main/java/com/hover/stax/domain/use_case/financial_tips/TipsUseCase.kt
+++ b/app/src/main/java/com/hover/stax/domain/use_case/financial_tips/TipsUseCase.kt
@@ -1,11 +1,13 @@
 package com.hover.stax.domain.use_case.financial_tips
 
+import androidx.compose.runtime.mutableStateOf
 import com.hover.stax.domain.model.FinancialTip
 import com.hover.stax.domain.model.Resource
 import com.hover.stax.domain.repository.FinancialTipsRepository
 import kotlinx.coroutines.flow.*
+import timber.log.Timber
 
-class GetTipsUseCase(private val financialTipsRepository: FinancialTipsRepository) {
+class TipsUseCase(private val financialTipsRepository: FinancialTipsRepository) {
 
     operator fun invoke(): Flow<Resource<List<FinancialTip>>> = flow {
         try {
@@ -18,4 +20,8 @@ class GetTipsUseCase(private val financialTipsRepository: FinancialTipsRepositor
         }
     }
 
+    fun getDismissedTipId() : String? = financialTipsRepository.getDismissedTipId()
+    fun dismissTip(id: String) {
+        financialTipsRepository.dismissTip(id)
+    }
 }

--- a/app/src/main/java/com/hover/stax/presentation/financial_tips/FinancialTipsViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/financial_tips/FinancialTipsViewModel.kt
@@ -3,13 +3,14 @@ package com.hover.stax.presentation.financial_tips
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hover.stax.domain.model.Resource
-import com.hover.stax.domain.use_case.financial_tips.GetTipsUseCase
+import com.hover.stax.domain.use_case.financial_tips.TipsUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
-class FinancialTipsViewModel(private val getTipsUseCase: GetTipsUseCase) : ViewModel() {
+class FinancialTipsViewModel(private val tipsUseCase: TipsUseCase) : ViewModel() {
+
 
     private val _tipsState = MutableStateFlow(FinancialTipsState())
     val tipsState = _tipsState.asStateFlow()
@@ -18,7 +19,7 @@ class FinancialTipsViewModel(private val getTipsUseCase: GetTipsUseCase) : ViewM
         getTips()
     }
 
-    fun getTips() = getTipsUseCase().onEach { result ->
+    fun getTips() = tipsUseCase().onEach { result ->
         when (result) {
             is Resource.Loading -> _tipsState.value = FinancialTipsState(isLoading = true)
             is Resource.Error -> _tipsState.value = FinancialTipsState(error = result.message ?: "An unexpected error occurred", isLoading = false)

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
@@ -375,7 +375,7 @@ fun HomeScreen(
 
 					item {
 						homeState.financialTips.firstOrNull {
-							!android.text.format.DateUtils.isToday(it.date!!)
+							android.text.format.DateUtils.isToday(it.date!!)
 						}?.let {
 							if (homeState.dismissedTipId != it.id) {
 								FinancialTipCard(

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
@@ -189,48 +189,47 @@ private fun FinancialTipCard(
 ) {
     val size13 = dimensionResource(id = R.dimen.margin_13)
     Card(elevation = 0.dp, modifier = Modifier.padding(all = size13)) {
-        Row(modifier = Modifier
-            .padding(all = size13)
-            .clickable { tipInterface?.onTipClicked(null) }) {
-
-            Column(modifier = Modifier.weight(1f)) {
-                HorizontalImageTextView(
-                    drawable = R.drawable.ic_tip_of_day,
+        Column {
+            Row(modifier = Modifier.fillMaxWidth().padding(all = size13)) {
+                HorizontalImageTextView(drawable = R.drawable.ic_tip_of_day,
                     stringRes = R.string.tip_of_the_day,
-                    Modifier.padding(bottom = 5.dp),
-                    MaterialTheme.typography.button
-                )
+                    Modifier.weight(1f),
+                    MaterialTheme.typography.button)
 
-                Spacer(modifier = Modifier.height(10.dp))
-
-                Text(
-                    text = financialTip.title,
-                    style = MaterialTheme.typography.body2,
-                    textDecoration = TextDecoration.Underline
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Text(
-                    text = financialTip.snippet,
-                    style = MaterialTheme.typography.body2,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.padding(bottom = size13, top = 3.dp)
-                )
-                Text(text = stringResource(id = R.string.read_more),
-                    color = colorResource(id = R.color.brightBlue),
-                    modifier = Modifier.clickable { tipInterface?.onTipClicked(financialTip.id) })
+                Image(painter = painterResource(id = R.drawable.ic_close_white),
+                    contentDescription = null,
+                    alignment = Alignment.CenterEnd)
             }
 
-            Image(
-                painter = painterResource(id = R.drawable.tips_fancy_icon),
-                contentDescription = null,
-                modifier = Modifier
-                    .size(60.dp)
-                    .padding(start = size13)
-                    .align(Alignment.CenterVertically),
-            )
+            Row(modifier = Modifier.padding(horizontal = size13)
+                .clickable { tipInterface?.onTipClicked(null) }) {
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Spacer(modifier = Modifier.height(10.dp))
+
+                    Text(text = financialTip.title,
+                        style = MaterialTheme.typography.body2,
+                        textDecoration = TextDecoration.Underline)
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(text = financialTip.snippet,
+                        style = MaterialTheme.typography.body2,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(bottom = size13, top = 3.dp))
+                    Text(text = stringResource(id = R.string.read_more),
+                        color = colorResource(id = R.color.brightBlue),
+                        modifier = Modifier.clickable { tipInterface?.onTipClicked(financialTip.id) })
+                }
+
+                Image(
+                    painter = painterResource(id = R.drawable.tips_fancy_icon),
+                    contentDescription = null,
+                    modifier = Modifier.size(60.dp).padding(start = size13)
+                        .align(Alignment.CenterVertically),
+                )
+            }
         }
     }
 }
@@ -419,11 +418,12 @@ fun HomeScreenPreview() {
                             )
                         }
                         item {
-                            BalanceScreenPreview()
-                        }
-                        item {
                             FinancialTipCard(tipInterface = null, financialTip = financialTip)
                         }
+                        item {
+                            BalanceScreenPreview()
+                        }
+
                     })
                 })
         }

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
@@ -1,7 +1,6 @@
 package com.hover.stax.presentation.home
 
 import android.content.Context
-import android.text.Html
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
@@ -28,7 +27,6 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.text.HtmlCompat
 import com.hover.stax.R
 import com.hover.stax.addChannels.ChannelsViewModel
 import com.hover.stax.domain.model.Bonus
@@ -36,396 +34,348 @@ import com.hover.stax.domain.model.FinancialTip
 import com.hover.stax.ui.theme.StaxTheme
 import com.hover.stax.utils.AnalyticsUtil
 import com.hover.stax.utils.network.NetworkMonitor
+import timber.log.Timber
 
-data class HomeClickFunctions(
-    val onSendMoneyClicked: () -> Unit,
-    val onBuyAirtimeClicked: () -> Unit,
-    val onBuyGoodsClicked: () -> Unit,
-    val onPayBillClicked: () -> Unit,
-    val onRequestMoneyClicked: () -> Unit,
-    val onClickedTC: () -> Unit,
-    val onClickedAddNewAccount: () -> Unit,
-    val onClickedSettingsIcon: () -> Unit
-)
+data class HomeClickFunctions(val onSendMoneyClicked: () -> Unit,
+                              val onBuyAirtimeClicked: () -> Unit,
+                              val onBuyGoodsClicked: () -> Unit,
+                              val onPayBillClicked: () -> Unit,
+                              val onRequestMoneyClicked: () -> Unit,
+                              val onClickedTC: () -> Unit,
+                              val onClickedAddNewAccount: () -> Unit,
+                              val onClickedSettingsIcon: () -> Unit)
 
 interface FinancialTipClickInterface {
-    fun onTipClicked(tipId: String?)
+	fun onTipClicked(tipId: String?)
 }
 
 @Composable
-fun TopBar(@StringRes title: Int = R.string.app_name, isInternetConnected: Boolean, onClickedSettingsIcon: () -> Unit) {
-    Row(
-        modifier = Modifier
+fun TopBar(@StringRes title: Int = R.string.app_name,
+           isInternetConnected: Boolean,
+           onClickedSettingsIcon: () -> Unit) {
+	Row(
+		modifier = Modifier
             .fillMaxWidth()
             .padding(all = dimensionResource(id = R.dimen.margin_13)),
-    ) {
-        HorizontalImageTextView(
-            drawable = R.drawable.stax_logo,
-            stringRes = title,
-            modifier = Modifier.weight(1f),
-            MaterialTheme.typography.button
-        )
+	) {
+		HorizontalImageTextView(drawable = R.drawable.stax_logo,
+			stringRes = title,
+			modifier = Modifier.weight(1f),
+			MaterialTheme.typography.button)
 
-        if (!isInternetConnected) {
-            HorizontalImageTextView(
-                drawable = R.drawable.ic_internet_off,
-                stringRes = R.string.working_offline,
-                modifier = Modifier
+		if (!isInternetConnected) {
+			HorizontalImageTextView(drawable = R.drawable.ic_internet_off,
+				stringRes = R.string.working_offline,
+				modifier = Modifier
                     .align(Alignment.CenterVertically)
                     .padding(horizontal = 16.dp),
-                MaterialTheme.typography.button
-            )
-        }
+				MaterialTheme.typography.button)
+		}
 
-        Image(
-            painter = painterResource(id = R.drawable.ic_settings),
-            contentDescription = null,
-            modifier = Modifier
+		Image(
+			painter = painterResource(id = R.drawable.ic_settings),
+			contentDescription = null,
+			modifier = Modifier
                 .align(Alignment.CenterVertically)
                 .clickable(onClick = onClickedSettingsIcon)
                 .size(25.dp),
-        )
-    }
+		)
+	}
 }
 
 @Composable
 fun BonusCard(message: String, onClickedTC: () -> Unit, onClickedTopUp: () -> Unit) {
-    val size13 = dimensionResource(id = R.dimen.margin_13)
-    val size10 = dimensionResource(id = R.dimen.margin_10)
+	val size13 = dimensionResource(id = R.dimen.margin_13)
+	val size10 = dimensionResource(id = R.dimen.margin_10)
 
-    Card(modifier = Modifier.padding(all = size13), elevation = 2.dp) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = size13)
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(id = R.string.get_rewarded),
-                    style = MaterialTheme.typography.h3
-                )
-                Text(
-                    text = message,
-                    modifier = Modifier.padding(vertical = size10),
-                    style = MaterialTheme.typography.body1
-                )
-                Text(
-                    text = stringResource(id = R.string.tc_apply),
-                    textDecoration = TextDecoration.Underline,
-                    color = colorResource(id = R.color.brightBlue),
-                    style = MaterialTheme.typography.body2,
-                    modifier = Modifier.clickable(onClick = onClickedTC)
-                )
-                Text(
-                    text = stringResource(id = R.string.top_up),
-                    color = colorResource(id = R.color.brightBlue),
-                    style = MaterialTheme.typography.h4,
-                    modifier = Modifier
+	Card(modifier = Modifier.padding(all = size13), elevation = 2.dp) {
+		Row(modifier = Modifier
+            .fillMaxWidth()
+            .padding(all = size13)) {
+			Column(modifier = Modifier.weight(1f)) {
+				Text(text = stringResource(id = R.string.get_rewarded),
+					style = MaterialTheme.typography.h3)
+				Text(text = message,
+					modifier = Modifier.padding(vertical = size10),
+					style = MaterialTheme.typography.body1)
+				Text(text = stringResource(id = R.string.tc_apply),
+					textDecoration = TextDecoration.Underline,
+					color = colorResource(id = R.color.brightBlue),
+					style = MaterialTheme.typography.body2,
+					modifier = Modifier.clickable(onClick = onClickedTC))
+				Text(text = stringResource(id = R.string.top_up),
+					color = colorResource(id = R.color.brightBlue),
+					style = MaterialTheme.typography.h4,
+					modifier = Modifier
                         .padding(top = size13)
-                        .clickable(onClick = onClickedTopUp)
-                )
-            }
-            Image(
-                painter = painterResource(id = R.drawable.ic_bonus),
-                contentDescription = stringResource(id = R.string.get_rewarded),
-                modifier = Modifier
+                        .clickable(onClick = onClickedTopUp))
+			}
+			Image(painter = painterResource(id = R.drawable.ic_bonus),
+				contentDescription = stringResource(id = R.string.get_rewarded),
+				modifier = Modifier
                     .size(70.dp)
                     .padding(start = size13)
-                    .align(Alignment.CenterVertically)
-            )
-        }
-    }
+                    .align(Alignment.CenterVertically))
+		}
+	}
 }
 
 @Composable
-fun PrimaryFeatures(
-    onSendMoneyClicked: () -> Unit,
-    onBuyAirtimeClicked: () -> Unit,
-    onBuyGoodsClicked: () -> Unit,
-    onPayBillClicked: () -> Unit,
-    onRequestMoneyClicked: () -> Unit,
-    showKenyaFeatures: Boolean
-) {
-    Row(
-        horizontalArrangement = Arrangement.SpaceEvenly,
-        modifier = Modifier
+fun PrimaryFeatures(onSendMoneyClicked: () -> Unit,
+                    onBuyAirtimeClicked: () -> Unit,
+                    onBuyGoodsClicked: () -> Unit,
+                    onPayBillClicked: () -> Unit,
+                    onRequestMoneyClicked: () -> Unit,
+                    showKenyaFeatures: Boolean) {
+	Row(horizontalArrangement = Arrangement.SpaceEvenly,
+		modifier = Modifier
             .padding(horizontal = 13.dp, vertical = 26.dp)
-            .fillMaxWidth()
-    ) {
-        VerticalImageTextView(
-            onItemClick = onSendMoneyClicked,
-            drawable = R.drawable.ic_transfer_within_24,
-            stringRes = R.string.cta_transfer
-        )
-        VerticalImageTextView(
-            onItemClick = onBuyAirtimeClicked,
-            drawable = R.drawable.ic_system_upate_24,
-            stringRes = R.string.cta_airtime
-        )
-        if (showKenyaFeatures) {
-            VerticalImageTextView(
-                onItemClick = onBuyGoodsClicked,
-                drawable = R.drawable.ic_card,
-                stringRes = R.string.cta_merchant
-            )
-            VerticalImageTextView(
-                onItemClick = onPayBillClicked,
-                drawable = R.drawable.ic_utility,
-                stringRes = R.string.cta_paybill_linebreak
-            )
-        }
-        VerticalImageTextView(
-            onItemClick = onRequestMoneyClicked,
-            drawable = R.drawable.ic_baseline_people_24,
-            stringRes = R.string.cta_request
-        )
-    }
+            .fillMaxWidth()) {
+		VerticalImageTextView(onItemClick = onSendMoneyClicked,
+			drawable = R.drawable.ic_transfer_within_24,
+			stringRes = R.string.cta_transfer)
+		VerticalImageTextView(onItemClick = onBuyAirtimeClicked,
+			drawable = R.drawable.ic_system_upate_24,
+			stringRes = R.string.cta_airtime)
+		if (showKenyaFeatures) {
+			VerticalImageTextView(onItemClick = onBuyGoodsClicked,
+				drawable = R.drawable.ic_card,
+				stringRes = R.string.cta_merchant)
+			VerticalImageTextView(onItemClick = onPayBillClicked,
+				drawable = R.drawable.ic_utility,
+				stringRes = R.string.cta_paybill_linebreak)
+		}
+		VerticalImageTextView(onItemClick = onRequestMoneyClicked,
+			drawable = R.drawable.ic_baseline_people_24,
+			stringRes = R.string.cta_request)
+	}
 }
 
 @Composable
-private fun FinancialTipCard(
-    tipInterface: FinancialTipClickInterface?,
-    financialTip: FinancialTip
-) {
-    val size13 = dimensionResource(id = R.dimen.margin_13)
-    Card(elevation = 0.dp, modifier = Modifier.padding(all = size13)) {
-        Column {
-            Row(modifier = Modifier.fillMaxWidth().padding(all = size13)) {
-                HorizontalImageTextView(drawable = R.drawable.ic_tip_of_day,
-                    stringRes = R.string.tip_of_the_day,
-                    Modifier.weight(1f),
-                    MaterialTheme.typography.button)
+private fun FinancialTipCard(tipInterface: FinancialTipClickInterface?,
+                             financialTip: FinancialTip,
+                             homeViewModel: HomeViewModel?) {
+	val size13 = dimensionResource(id = R.dimen.margin_13)
+	Card(elevation = 0.dp, modifier = Modifier.padding(all = size13)) {
+		Column {
+			Row(modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = size13)) {
+				HorizontalImageTextView(drawable = R.drawable.ic_tip_of_day,
+					stringRes = R.string.tip_of_the_day,
+					Modifier.weight(1f),
+					MaterialTheme.typography.button)
 
-                Image(painter = painterResource(id = R.drawable.ic_close_white),
-                    contentDescription = null,
-                    alignment = Alignment.CenterEnd)
-            }
+				Image(painter = painterResource(id = R.drawable.ic_close_white),
+					contentDescription = null,
+					alignment = Alignment.CenterEnd,
+					modifier = Modifier.clickable { homeViewModel?.dismissTip(financialTip.id) })
+			}
 
-            Row(modifier = Modifier.padding(start = size13, end = size13, bottom = size13)
+			Row(modifier = Modifier
+                .padding(start = size13, end = size13, bottom = size13)
                 .clickable { tipInterface?.onTipClicked(null) }) {
 
-                Column(modifier = Modifier.weight(1f)) {
-                    Spacer(modifier = Modifier.height(10.dp))
+				Column(modifier = Modifier.weight(1f)) {
+					Spacer(modifier = Modifier.height(10.dp))
 
-                    Text(text = financialTip.title,
-                        style = MaterialTheme.typography.body2,
-                        textDecoration = TextDecoration.Underline)
+					Text(text = financialTip.title,
+						style = MaterialTheme.typography.body2,
+						textDecoration = TextDecoration.Underline)
 
-                    Spacer(modifier = Modifier.height(8.dp))
+					Spacer(modifier = Modifier.height(8.dp))
 
-                    Text(text = financialTip.snippet,
-                        style = MaterialTheme.typography.body2,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.padding(bottom = size13, top = 3.dp))
-                    Text(text = stringResource(id = R.string.read_more),
-                        color = colorResource(id = R.color.brightBlue),
-                        modifier = Modifier.clickable { tipInterface?.onTipClicked(financialTip.id) })
-                }
+					Text(text = financialTip.snippet,
+						style = MaterialTheme.typography.body2,
+						maxLines = 2,
+						overflow = TextOverflow.Ellipsis,
+						modifier = Modifier.padding(bottom = size13, top = 3.dp))
+					Text(text = stringResource(id = R.string.read_more),
+						color = colorResource(id = R.color.brightBlue),
+						modifier = Modifier.clickable { tipInterface?.onTipClicked(financialTip.id) })
+				}
 
-                Image(
-                    painter = painterResource(id = R.drawable.tips_fancy_icon),
-                    contentDescription = null,
-                    modifier = Modifier.size(60.dp).padding(start = size13)
+				Image(
+					painter = painterResource(id = R.drawable.tips_fancy_icon),
+					contentDescription = null,
+					modifier = Modifier
+                        .size(60.dp)
+                        .padding(start = size13)
                         .align(Alignment.CenterVertically),
-                )
-            }
-        }
-    }
+				)
+			}
+		}
+	}
 }
 
 @Composable
-private fun VerticalImageTextView(
-    @DrawableRes drawable: Int,
-    @StringRes stringRes: Int,
-    onItemClick: () -> Unit
-) {
-    val size24 = dimensionResource(id = R.dimen.margin_24)
-    val blue = colorResource(id = R.color.stax_state_blue)
-    Column(
-        modifier = Modifier
-            .clickable(onClick = onItemClick)
-            .padding(horizontal = 2.dp),
-        verticalArrangement = Arrangement.Center
-    ) {
-        Image(painter = painterResource(id = drawable),
-            contentDescription = null,
+private fun VerticalImageTextView(@DrawableRes drawable: Int,
+                                  @StringRes stringRes: Int,
+                                  onItemClick: () -> Unit) {
+	val size24 = dimensionResource(id = R.dimen.margin_24)
+	val blue = colorResource(id = R.color.stax_state_blue)
+	Column(modifier = Modifier
+        .clickable(onClick = onItemClick)
+        .padding(horizontal = 2.dp),
+		verticalArrangement = Arrangement.Center) {
+		Image(painter = painterResource(id = drawable),
+			contentDescription = null,
             Modifier
                 .size(size24)
                 .align(Alignment.CenterHorizontally)
                 .drawBehind {
                     drawCircle(radius = this.size.minDimension, color = blue)
                 })
-        Text(
-            text = stringResource(id = stringRes),
-            color = colorResource(id = R.color.offWhite),
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.caption,
-            modifier = Modifier
+		Text(text = stringResource(id = stringRes),
+			color = colorResource(id = R.color.offWhite),
+			textAlign = TextAlign.Center,
+			style = MaterialTheme.typography.caption,
+			modifier = Modifier
                 .padding(top = size24)
-                .widthIn(min = 50.dp, max = 65.dp)
-        )
-    }
+                .widthIn(min = 50.dp, max = 65.dp))
+	}
 }
 
 @Composable
-internal fun HorizontalImageTextView(
-    @DrawableRes drawable: Int,
-    @StringRes stringRes: Int,
-    modifier: Modifier = Modifier, textStyle: TextStyle
-) {
-    Row(horizontalArrangement = Arrangement.Start, modifier = modifier) {
-        Image(
-            painter = painterResource(id = drawable),
-            contentDescription = null,
-            modifier = Modifier.align(Alignment.CenterVertically),
-        )
-        Text(
-            text = stringResource(id = stringRes),
-            style = textStyle,
-            modifier = Modifier
+internal fun HorizontalImageTextView(@DrawableRes drawable: Int,
+                                     @StringRes stringRes: Int,
+                                     modifier: Modifier = Modifier,
+                                     textStyle: TextStyle) {
+	Row(horizontalArrangement = Arrangement.Start, modifier = modifier) {
+		Image(
+			painter = painterResource(id = drawable),
+			contentDescription = null,
+			modifier = Modifier.align(Alignment.CenterVertically),
+		)
+		Text(text = stringResource(id = stringRes),
+			style = textStyle,
+			modifier = Modifier
                 .padding(start = dimensionResource(id = R.dimen.margin_13))
                 .align(Alignment.CenterVertically),
-            color = colorResource(id = R.color.offWhite)
-        )
-    }
+			color = colorResource(id = R.color.offWhite))
+	}
 }
 
 @Composable
-fun HomeScreen(
-    channelsViewModel: ChannelsViewModel,
-    homeClickFunctions: HomeClickFunctions,
-    balanceTapListener: BalanceTapListener,
-    tipInterface: FinancialTipClickInterface,
-    homeViewModel: HomeViewModel
-) {
-    val homeState by homeViewModel.homeState.collectAsState()
-    val hasNetwork by NetworkMonitor.StateLiveData.get().observeAsState(initial = false)
-    val simCountryList by channelsViewModel.simCountryList.observeAsState(initial = emptyList())
-    val accounts by homeViewModel.accounts.observeAsState(initial = emptyList())
-    val context = LocalContext.current
+fun HomeScreen(channelsViewModel: ChannelsViewModel,
+               homeClickFunctions: HomeClickFunctions,
+               balanceTapListener: BalanceTapListener,
+               tipInterface: FinancialTipClickInterface,
+               homeViewModel: HomeViewModel) {
+	val homeState by homeViewModel.homeState.collectAsState()
+	val hasNetwork by NetworkMonitor.StateLiveData.get().observeAsState(initial = false)
+	val simCountryList by channelsViewModel.simCountryList.observeAsState(initial = emptyList())
+	val accounts by homeViewModel.accounts.observeAsState(initial = emptyList())
+	val context = LocalContext.current
 
-    StaxTheme {
-        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
-            Scaffold(
-                topBar = { TopBar(title = R.string.nav_home, isInternetConnected = hasNetwork, homeClickFunctions.onClickedSettingsIcon) },
-                content = {
-                    LazyColumn {
-                        item {
-                            if (homeState.bonuses.isNotEmpty()) {
-                                BonusCard(message = homeState.bonuses.first().message,
-                                    onClickedTC = homeClickFunctions.onClickedTC,
-                                    onClickedTopUp = {
-                                        clickedOnBonus(
-                                            context,
-                                            channelsViewModel,
-                                            homeState.bonuses.first()
-                                        )
-                                    })
-                            }
-                        }
+	StaxTheme {
+		Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
+			Scaffold(topBar = {
+				TopBar(title = R.string.nav_home,
+					isInternetConnected = hasNetwork,
+					homeClickFunctions.onClickedSettingsIcon)
+			}, content = {
+				LazyColumn {
+					item {
+						if (homeState.bonuses.isNotEmpty()) {
+							BonusCard(message = homeState.bonuses.first().message,
+								onClickedTC = homeClickFunctions.onClickedTC,
+								onClickedTopUp = {
+									clickedOnBonus(context,
+										channelsViewModel,
+										homeState.bonuses.first())
+								})
+						}
+					}
 
-                        item {
-                            PrimaryFeatures(
-                                onSendMoneyClicked = homeClickFunctions.onSendMoneyClicked,
-                                onBuyAirtimeClicked = homeClickFunctions.onBuyAirtimeClicked,
-                                onBuyGoodsClicked = homeClickFunctions.onBuyGoodsClicked,
-                                onPayBillClicked = homeClickFunctions.onPayBillClicked,
-                                onRequestMoneyClicked = homeClickFunctions.onRequestMoneyClicked,
-                                showKEFeatures(simCountryList)
-                            )
-                        }
+					item {
+						PrimaryFeatures(onSendMoneyClicked = homeClickFunctions.onSendMoneyClicked,
+							onBuyAirtimeClicked = homeClickFunctions.onBuyAirtimeClicked,
+							onBuyGoodsClicked = homeClickFunctions.onBuyGoodsClicked,
+							onPayBillClicked = homeClickFunctions.onPayBillClicked,
+							onRequestMoneyClicked = homeClickFunctions.onRequestMoneyClicked,
+							showKEFeatures(simCountryList))
+					}
 
-                        item {
-                            BalanceHeader(
-                                onClickedAddAccount = homeClickFunctions.onClickedAddNewAccount, homeState.accounts.isNotEmpty()
-                            )
+					item {
+						BalanceHeader(onClickedAddAccount = homeClickFunctions.onClickedAddNewAccount,
+							homeState.accounts.isNotEmpty())
 
-                            if (accounts.isEmpty()) {
-                                EmptyBalance(onClickedAddAccount = homeClickFunctions.onClickedAddNewAccount)
-                            }
-                        }
+						if (accounts.isEmpty()) {
+							EmptyBalance(onClickedAddAccount = homeClickFunctions.onClickedAddNewAccount)
+						}
+					}
 
-                        items(accounts){ account ->
-                            BalanceItem(
-                                staxAccount = account,
-                                context = context,
-                                balanceTapListener = balanceTapListener
-                            )
-                        }
+					items(accounts) { account ->
+						BalanceItem(staxAccount = account,
+							context = context,
+							balanceTapListener = balanceTapListener)
+					}
 
-                        item {
-                            homeState.financialTips.firstOrNull {
-                                android.text.format.DateUtils.isToday(it.date!!)
-                            }?.let {
-                                FinancialTipCard(
-                                    tipInterface = tipInterface,
-                                    financialTip = homeState.financialTips.first()
-                                )
-                            }
-                        }
-                    }
-                }
-            )
-        }
-    }
+					item {
+						homeState.financialTips.firstOrNull {
+							!android.text.format.DateUtils.isToday(it.date!!)
+						}?.let {
+							if (homeState.dismissedTipId != it.id) {
+								FinancialTipCard(tipInterface = tipInterface,
+									financialTip = it,
+									homeViewModel)
+							}
+						}
+					}
+				}
+			})
+		}
+	}
 }
 
 private fun clickedOnBonus(context: Context, channelsViewModel: ChannelsViewModel, bonus: Bonus) {
-    AnalyticsUtil.logAnalyticsEvent(
-        context.getString(R.string.clicked_bonus_airtime_banner),
-        context
-    )
-    channelsViewModel.validateAccounts(bonus.userChannel)
+	AnalyticsUtil.logAnalyticsEvent(context.getString(R.string.clicked_bonus_airtime_banner),
+		context)
+	channelsViewModel.validateAccounts(bonus.userChannel)
 }
 
-private fun showKEFeatures(countryIsos: List<String>): Boolean = countryIsos.any { it.contentEquals("KE", ignoreCase = true) }
+private fun showKEFeatures(countryIsos: List<String>): Boolean =
+	countryIsos.any { it.contentEquals("KE", ignoreCase = true) }
 
 @Preview
 @Composable
 fun HomeScreenPreview() {
-    val financialTip = FinancialTip(
-        id = "1234",
-        title = "Do you want to save money",
-        content = "This is a test content here so lets see if its going to use ellipse overflow",
-        snippet = "This is a test content here so lets see if its going to use ellipse overflow, with an example here",
-        date = System.currentTimeMillis(),
-        shareCopy = null,
-        deepLink = null
-    )
+	val financialTip = FinancialTip(id = "1234",
+		title = "Do you want to save money",
+		content = "This is a test content here so lets see if its going to use ellipse overflow",
+		snippet = "This is a test content here so lets see if its going to use ellipse overflow, with an example here",
+		date = System.currentTimeMillis(),
+		shareCopy = null,
+		deepLink = null)
 
-    StaxTheme {
-        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
-            Scaffold(
-                topBar = {
-                    TopBar(title = R.string.nav_home, isInternetConnected = false) {}
-                },
-                content = {
-                    LazyColumn(content = {
-                        item {
-                            BonusCard(message = "Buy at least Ksh 50 airtime on Stax to get 3% or more bonus airtime",
-                                onClickedTC = {},
-                                onClickedTopUp = {})
-                        }
-                        item {
-                            PrimaryFeatures(
-                                onSendMoneyClicked = { },
-                                onBuyAirtimeClicked = { },
-                                onBuyGoodsClicked = { },
-                                onPayBillClicked = { },
-                                onRequestMoneyClicked = {},
-                                true
-                            )
-                        }
-                        item {
-                            FinancialTipCard(tipInterface = null, financialTip = financialTip)
-                        }
-                        item {
-                            BalanceScreenPreview()
-                        }
-
-                    })
-                })
-        }
-    }
+	StaxTheme {
+		Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
+			Scaffold(topBar = {
+				TopBar(title = R.string.nav_home, isInternetConnected = false) {}
+			}, content = {
+				LazyColumn(content = {
+					item {
+						BonusCard(message = "Buy at least Ksh 50 airtime on Stax to get 3% or more bonus airtime",
+							onClickedTC = {},
+							onClickedTopUp = {})
+					}
+					item {
+						PrimaryFeatures(onSendMoneyClicked = { },
+							onBuyAirtimeClicked = { },
+							onBuyGoodsClicked = { },
+							onPayBillClicked = { },
+							onRequestMoneyClicked = {},
+							true)
+					}
+					item {
+						BalanceScreenPreview()
+					}
+					item {
+						FinancialTipCard(tipInterface = null, financialTip = financialTip, null)
+					}
+				})
+			})
+		}
+	}
 }

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
@@ -34,7 +34,6 @@ import com.hover.stax.domain.model.FinancialTip
 import com.hover.stax.ui.theme.StaxTheme
 import com.hover.stax.utils.AnalyticsUtil
 import com.hover.stax.utils.network.NetworkMonitor
-import timber.log.Timber
 
 data class HomeClickFunctions(val onSendMoneyClicked: () -> Unit,
                               val onBuyAirtimeClicked: () -> Unit,
@@ -55,8 +54,8 @@ fun TopBar(@StringRes title: Int = R.string.app_name,
            onClickedSettingsIcon: () -> Unit) {
 	Row(
 		modifier = Modifier
-            .fillMaxWidth()
-            .padding(all = dimensionResource(id = R.dimen.margin_13)),
+			.fillMaxWidth()
+			.padding(all = dimensionResource(id = R.dimen.margin_13)),
 	) {
 		HorizontalImageTextView(drawable = R.drawable.stax_logo,
 			stringRes = title,
@@ -67,8 +66,8 @@ fun TopBar(@StringRes title: Int = R.string.app_name,
 			HorizontalImageTextView(drawable = R.drawable.ic_internet_off,
 				stringRes = R.string.working_offline,
 				modifier = Modifier
-                    .align(Alignment.CenterVertically)
-                    .padding(horizontal = 16.dp),
+					.align(Alignment.CenterVertically)
+					.padding(horizontal = 16.dp),
 				MaterialTheme.typography.button)
 		}
 
@@ -76,9 +75,9 @@ fun TopBar(@StringRes title: Int = R.string.app_name,
 			painter = painterResource(id = R.drawable.ic_settings),
 			contentDescription = null,
 			modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .clickable(onClick = onClickedSettingsIcon)
-                .size(25.dp),
+				.align(Alignment.CenterVertically)
+				.clickable(onClick = onClickedSettingsIcon)
+				.size(25.dp),
 		)
 	}
 }
@@ -90,8 +89,8 @@ fun BonusCard(message: String, onClickedTC: () -> Unit, onClickedTopUp: () -> Un
 
 	Card(modifier = Modifier.padding(all = size13), elevation = 2.dp) {
 		Row(modifier = Modifier
-            .fillMaxWidth()
-            .padding(all = size13)) {
+			.fillMaxWidth()
+			.padding(all = size13)) {
 			Column(modifier = Modifier.weight(1f)) {
 				Text(text = stringResource(id = R.string.get_rewarded),
 					style = MaterialTheme.typography.h3)
@@ -107,15 +106,15 @@ fun BonusCard(message: String, onClickedTC: () -> Unit, onClickedTopUp: () -> Un
 					color = colorResource(id = R.color.brightBlue),
 					style = MaterialTheme.typography.h4,
 					modifier = Modifier
-                        .padding(top = size13)
-                        .clickable(onClick = onClickedTopUp))
+						.padding(top = size13)
+						.clickable(onClick = onClickedTopUp))
 			}
 			Image(painter = painterResource(id = R.drawable.ic_bonus),
 				contentDescription = stringResource(id = R.string.get_rewarded),
 				modifier = Modifier
-                    .size(70.dp)
-                    .padding(start = size13)
-                    .align(Alignment.CenterVertically))
+					.size(70.dp)
+					.padding(start = size13)
+					.align(Alignment.CenterVertically))
 		}
 	}
 }
@@ -129,8 +128,8 @@ fun PrimaryFeatures(onSendMoneyClicked: () -> Unit,
                     showKenyaFeatures: Boolean) {
 	Row(horizontalArrangement = Arrangement.SpaceEvenly,
 		modifier = Modifier
-            .padding(horizontal = 13.dp, vertical = 26.dp)
-            .fillMaxWidth()) {
+			.padding(horizontal = 13.dp, vertical = 26.dp)
+			.fillMaxWidth()) {
 		VerticalImageTextView(onItemClick = onSendMoneyClicked,
 			drawable = R.drawable.ic_transfer_within_24,
 			stringRes = R.string.cta_transfer)
@@ -159,8 +158,8 @@ private fun FinancialTipCard(tipInterface: FinancialTipClickInterface?,
 	Card(elevation = 0.dp, modifier = Modifier.padding(all = size13)) {
 		Column {
 			Row(modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = size13)) {
+				.fillMaxWidth()
+				.padding(all = size13)) {
 				HorizontalImageTextView(drawable = R.drawable.ic_tip_of_day,
 					stringRes = R.string.tip_of_the_day,
 					Modifier.weight(1f),
@@ -173,8 +172,8 @@ private fun FinancialTipCard(tipInterface: FinancialTipClickInterface?,
 			}
 
 			Row(modifier = Modifier
-                .padding(start = size13, end = size13, bottom = size13)
-                .clickable { tipInterface?.onTipClicked(null) }) {
+				.padding(start = size13, end = size13, bottom = size13)
+				.clickable { tipInterface?.onTipClicked(null) }) {
 
 				Column(modifier = Modifier.weight(1f)) {
 					Spacer(modifier = Modifier.height(10.dp))
@@ -199,9 +198,9 @@ private fun FinancialTipCard(tipInterface: FinancialTipClickInterface?,
 					painter = painterResource(id = R.drawable.tips_fancy_icon),
 					contentDescription = null,
 					modifier = Modifier
-                        .size(60.dp)
-                        .padding(start = size13)
-                        .align(Alignment.CenterVertically),
+						.size(60.dp)
+						.padding(start = size13)
+						.align(Alignment.CenterVertically),
 				)
 			}
 		}
@@ -215,24 +214,24 @@ private fun VerticalImageTextView(@DrawableRes drawable: Int,
 	val size24 = dimensionResource(id = R.dimen.margin_24)
 	val blue = colorResource(id = R.color.stax_state_blue)
 	Column(modifier = Modifier
-        .clickable(onClick = onItemClick)
-        .padding(horizontal = 2.dp),
+		.clickable(onClick = onItemClick)
+		.padding(horizontal = 2.dp),
 		verticalArrangement = Arrangement.Center) {
 		Image(painter = painterResource(id = drawable),
 			contentDescription = null,
-            Modifier
-                .size(size24)
-                .align(Alignment.CenterHorizontally)
-                .drawBehind {
-                    drawCircle(radius = this.size.minDimension, color = blue)
-                })
+			Modifier
+				.size(size24)
+				.align(Alignment.CenterHorizontally)
+				.drawBehind {
+					drawCircle(radius = this.size.minDimension, color = blue)
+				})
 		Text(text = stringResource(id = stringRes),
 			color = colorResource(id = R.color.offWhite),
 			textAlign = TextAlign.Center,
 			style = MaterialTheme.typography.caption,
 			modifier = Modifier
-                .padding(top = size24)
-                .widthIn(min = 50.dp, max = 65.dp))
+				.padding(top = size24)
+				.widthIn(min = 50.dp, max = 65.dp))
 	}
 }
 
@@ -250,8 +249,8 @@ internal fun HorizontalImageTextView(@DrawableRes drawable: Int,
 		Text(text = stringResource(id = stringRes),
 			style = textStyle,
 			modifier = Modifier
-                .padding(start = dimensionResource(id = R.dimen.margin_13))
-                .align(Alignment.CenterVertically),
+				.padding(start = dimensionResource(id = R.dimen.margin_13))
+				.align(Alignment.CenterVertically),
 			color = colorResource(id = R.color.offWhite))
 	}
 }

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
@@ -35,40 +35,48 @@ import com.hover.stax.ui.theme.StaxTheme
 import com.hover.stax.utils.AnalyticsUtil
 import com.hover.stax.utils.network.NetworkMonitor
 
-data class HomeClickFunctions(val onSendMoneyClicked: () -> Unit,
-                              val onBuyAirtimeClicked: () -> Unit,
-                              val onBuyGoodsClicked: () -> Unit,
-                              val onPayBillClicked: () -> Unit,
-                              val onRequestMoneyClicked: () -> Unit,
-                              val onClickedTC: () -> Unit,
-                              val onClickedAddNewAccount: () -> Unit,
-                              val onClickedSettingsIcon: () -> Unit)
+data class HomeClickFunctions(
+	val onSendMoneyClicked: () -> Unit,
+	val onBuyAirtimeClicked: () -> Unit,
+	val onBuyGoodsClicked: () -> Unit,
+	val onPayBillClicked: () -> Unit,
+	val onRequestMoneyClicked: () -> Unit,
+	val onClickedTC: () -> Unit,
+	val onClickedAddNewAccount: () -> Unit,
+	val onClickedSettingsIcon: () -> Unit
+)
 
 interface FinancialTipClickInterface {
 	fun onTipClicked(tipId: String?)
 }
 
 @Composable
-fun TopBar(@StringRes title: Int = R.string.app_name,
-           isInternetConnected: Boolean,
-           onClickedSettingsIcon: () -> Unit) {
+fun TopBar(
+	@StringRes title: Int = R.string.app_name,
+	isInternetConnected: Boolean,
+	onClickedSettingsIcon: () -> Unit
+) {
 	Row(
 		modifier = Modifier
 			.fillMaxWidth()
 			.padding(all = dimensionResource(id = R.dimen.margin_13)),
 	) {
-		HorizontalImageTextView(drawable = R.drawable.stax_logo,
+		HorizontalImageTextView(
+			drawable = R.drawable.stax_logo,
 			stringRes = title,
 			modifier = Modifier.weight(1f),
-			MaterialTheme.typography.button)
+			MaterialTheme.typography.button
+		)
 
 		if (!isInternetConnected) {
-			HorizontalImageTextView(drawable = R.drawable.ic_internet_off,
+			HorizontalImageTextView(
+				drawable = R.drawable.ic_internet_off,
 				stringRes = R.string.working_offline,
 				modifier = Modifier
 					.align(Alignment.CenterVertically)
 					.padding(horizontal = 16.dp),
-				MaterialTheme.typography.button)
+				MaterialTheme.typography.button
+			)
 		}
 
 		Image(
@@ -88,82 +96,114 @@ fun BonusCard(message: String, onClickedTC: () -> Unit, onClickedTopUp: () -> Un
 	val size10 = dimensionResource(id = R.dimen.margin_10)
 
 	Card(modifier = Modifier.padding(all = size13), elevation = 2.dp) {
-		Row(modifier = Modifier
-			.fillMaxWidth()
-			.padding(all = size13)) {
+		Row(
+			modifier = Modifier
+				.fillMaxWidth()
+				.padding(all = size13)
+		) {
 			Column(modifier = Modifier.weight(1f)) {
-				Text(text = stringResource(id = R.string.get_rewarded),
-					style = MaterialTheme.typography.h3)
-				Text(text = message,
+				Text(
+					text = stringResource(id = R.string.get_rewarded),
+					style = MaterialTheme.typography.h3
+				)
+				Text(
+					text = message,
 					modifier = Modifier.padding(vertical = size10),
-					style = MaterialTheme.typography.body1)
-				Text(text = stringResource(id = R.string.tc_apply),
+					style = MaterialTheme.typography.body1
+				)
+				Text(
+					text = stringResource(id = R.string.tc_apply),
 					textDecoration = TextDecoration.Underline,
 					color = colorResource(id = R.color.brightBlue),
 					style = MaterialTheme.typography.body2,
-					modifier = Modifier.clickable(onClick = onClickedTC))
-				Text(text = stringResource(id = R.string.top_up),
+					modifier = Modifier.clickable(onClick = onClickedTC)
+				)
+				Text(
+					text = stringResource(id = R.string.top_up),
 					color = colorResource(id = R.color.brightBlue),
 					style = MaterialTheme.typography.h4,
 					modifier = Modifier
 						.padding(top = size13)
-						.clickable(onClick = onClickedTopUp))
+						.clickable(onClick = onClickedTopUp)
+				)
 			}
-			Image(painter = painterResource(id = R.drawable.ic_bonus),
+			Image(
+				painter = painterResource(id = R.drawable.ic_bonus),
 				contentDescription = stringResource(id = R.string.get_rewarded),
 				modifier = Modifier
 					.size(70.dp)
 					.padding(start = size13)
-					.align(Alignment.CenterVertically))
+					.align(Alignment.CenterVertically)
+			)
 		}
 	}
 }
 
 @Composable
-fun PrimaryFeatures(onSendMoneyClicked: () -> Unit,
-                    onBuyAirtimeClicked: () -> Unit,
-                    onBuyGoodsClicked: () -> Unit,
-                    onPayBillClicked: () -> Unit,
-                    onRequestMoneyClicked: () -> Unit,
-                    showKenyaFeatures: Boolean) {
-	Row(horizontalArrangement = Arrangement.SpaceEvenly,
+fun PrimaryFeatures(
+	onSendMoneyClicked: () -> Unit,
+	onBuyAirtimeClicked: () -> Unit,
+	onBuyGoodsClicked: () -> Unit,
+	onPayBillClicked: () -> Unit,
+	onRequestMoneyClicked: () -> Unit,
+	showKenyaFeatures: Boolean
+) {
+	Row(
+		horizontalArrangement = Arrangement.SpaceEvenly,
 		modifier = Modifier
 			.padding(horizontal = 13.dp, vertical = 26.dp)
-			.fillMaxWidth()) {
-		VerticalImageTextView(onItemClick = onSendMoneyClicked,
+			.fillMaxWidth()
+	) {
+		VerticalImageTextView(
+			onItemClick = onSendMoneyClicked,
 			drawable = R.drawable.ic_transfer_within_24,
-			stringRes = R.string.cta_transfer)
-		VerticalImageTextView(onItemClick = onBuyAirtimeClicked,
+			stringRes = R.string.cta_transfer
+		)
+		VerticalImageTextView(
+			onItemClick = onBuyAirtimeClicked,
 			drawable = R.drawable.ic_system_upate_24,
-			stringRes = R.string.cta_airtime)
+			stringRes = R.string.cta_airtime
+		)
 		if (showKenyaFeatures) {
-			VerticalImageTextView(onItemClick = onBuyGoodsClicked,
+			VerticalImageTextView(
+				onItemClick = onBuyGoodsClicked,
 				drawable = R.drawable.ic_card,
-				stringRes = R.string.cta_merchant)
-			VerticalImageTextView(onItemClick = onPayBillClicked,
+				stringRes = R.string.cta_merchant
+			)
+			VerticalImageTextView(
+				onItemClick = onPayBillClicked,
 				drawable = R.drawable.ic_utility,
-				stringRes = R.string.cta_paybill_linebreak)
+				stringRes = R.string.cta_paybill_linebreak
+			)
 		}
-		VerticalImageTextView(onItemClick = onRequestMoneyClicked,
+		VerticalImageTextView(
+			onItemClick = onRequestMoneyClicked,
 			drawable = R.drawable.ic_baseline_people_24,
-			stringRes = R.string.cta_request)
+			stringRes = R.string.cta_request
+		)
 	}
 }
 
 @Composable
-private fun FinancialTipCard(tipInterface: FinancialTipClickInterface?,
-                             financialTip: FinancialTip,
-                             homeViewModel: HomeViewModel?) {
+private fun FinancialTipCard(
+	tipInterface: FinancialTipClickInterface?,
+	financialTip: FinancialTip,
+	homeViewModel: HomeViewModel?
+) {
 	val size13 = dimensionResource(id = R.dimen.margin_13)
 	Card(elevation = 0.dp, modifier = Modifier.padding(all = size13)) {
 		Column {
-			Row(modifier = Modifier
-				.fillMaxWidth()
-				.padding(all = size13)) {
-				HorizontalImageTextView(drawable = R.drawable.ic_tip_of_day,
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(all = size13)
+			) {
+				HorizontalImageTextView(
+					drawable = R.drawable.ic_tip_of_day,
 					stringRes = R.string.tip_of_the_day,
 					Modifier.weight(1f),
-					MaterialTheme.typography.button)
+					MaterialTheme.typography.button
+				)
 
 				Image(painter = painterResource(id = R.drawable.ic_close_white),
 					contentDescription = null,
@@ -178,17 +218,21 @@ private fun FinancialTipCard(tipInterface: FinancialTipClickInterface?,
 				Column(modifier = Modifier.weight(1f)) {
 					Spacer(modifier = Modifier.height(10.dp))
 
-					Text(text = financialTip.title,
+					Text(
+						text = financialTip.title,
 						style = MaterialTheme.typography.body2,
-						textDecoration = TextDecoration.Underline)
+						textDecoration = TextDecoration.Underline
+					)
 
 					Spacer(modifier = Modifier.height(8.dp))
 
-					Text(text = financialTip.snippet,
+					Text(
+						text = financialTip.snippet,
 						style = MaterialTheme.typography.body2,
 						maxLines = 2,
 						overflow = TextOverflow.Ellipsis,
-						modifier = Modifier.padding(bottom = size13, top = 3.dp))
+						modifier = Modifier.padding(bottom = size13, top = 3.dp)
+					)
 					Text(text = stringResource(id = R.string.read_more),
 						color = colorResource(id = R.color.brightBlue),
 						modifier = Modifier.clickable { tipInterface?.onTipClicked(financialTip.id) })
@@ -208,15 +252,17 @@ private fun FinancialTipCard(tipInterface: FinancialTipClickInterface?,
 }
 
 @Composable
-private fun VerticalImageTextView(@DrawableRes drawable: Int,
-                                  @StringRes stringRes: Int,
-                                  onItemClick: () -> Unit) {
+private fun VerticalImageTextView(
+	@DrawableRes drawable: Int, @StringRes stringRes: Int, onItemClick: () -> Unit
+) {
 	val size24 = dimensionResource(id = R.dimen.margin_24)
 	val blue = colorResource(id = R.color.stax_state_blue)
-	Column(modifier = Modifier
-		.clickable(onClick = onItemClick)
-		.padding(horizontal = 2.dp),
-		verticalArrangement = Arrangement.Center) {
+	Column(
+		modifier = Modifier
+			.clickable(onClick = onItemClick)
+			.padding(horizontal = 2.dp),
+		verticalArrangement = Arrangement.Center
+	) {
 		Image(painter = painterResource(id = drawable),
 			contentDescription = null,
 			Modifier
@@ -225,42 +271,50 @@ private fun VerticalImageTextView(@DrawableRes drawable: Int,
 				.drawBehind {
 					drawCircle(radius = this.size.minDimension, color = blue)
 				})
-		Text(text = stringResource(id = stringRes),
+		Text(
+			text = stringResource(id = stringRes),
 			color = colorResource(id = R.color.offWhite),
 			textAlign = TextAlign.Center,
 			style = MaterialTheme.typography.caption,
 			modifier = Modifier
 				.padding(top = size24)
-				.widthIn(min = 50.dp, max = 65.dp))
+				.widthIn(min = 50.dp, max = 65.dp)
+		)
 	}
 }
 
 @Composable
-internal fun HorizontalImageTextView(@DrawableRes drawable: Int,
-                                     @StringRes stringRes: Int,
-                                     modifier: Modifier = Modifier,
-                                     textStyle: TextStyle) {
+internal fun HorizontalImageTextView(
+	@DrawableRes drawable: Int,
+	@StringRes stringRes: Int,
+	modifier: Modifier = Modifier,
+	textStyle: TextStyle
+) {
 	Row(horizontalArrangement = Arrangement.Start, modifier = modifier) {
 		Image(
 			painter = painterResource(id = drawable),
 			contentDescription = null,
 			modifier = Modifier.align(Alignment.CenterVertically),
 		)
-		Text(text = stringResource(id = stringRes),
+		Text(
+			text = stringResource(id = stringRes),
 			style = textStyle,
 			modifier = Modifier
 				.padding(start = dimensionResource(id = R.dimen.margin_13))
 				.align(Alignment.CenterVertically),
-			color = colorResource(id = R.color.offWhite))
+			color = colorResource(id = R.color.offWhite)
+		)
 	}
 }
 
 @Composable
-fun HomeScreen(channelsViewModel: ChannelsViewModel,
-               homeClickFunctions: HomeClickFunctions,
-               balanceTapListener: BalanceTapListener,
-               tipInterface: FinancialTipClickInterface,
-               homeViewModel: HomeViewModel) {
+fun HomeScreen(
+	channelsViewModel: ChannelsViewModel,
+	homeClickFunctions: HomeClickFunctions,
+	balanceTapListener: BalanceTapListener,
+	tipInterface: FinancialTipClickInterface,
+	homeViewModel: HomeViewModel
+) {
 	val homeState by homeViewModel.homeState.collectAsState()
 	val hasNetwork by NetworkMonitor.StateLiveData.get().observeAsState(initial = false)
 	val simCountryList by channelsViewModel.simCountryList.observeAsState(initial = emptyList())
@@ -270,9 +324,11 @@ fun HomeScreen(channelsViewModel: ChannelsViewModel,
 	StaxTheme {
 		Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
 			Scaffold(topBar = {
-				TopBar(title = R.string.nav_home,
+				TopBar(
+					title = R.string.nav_home,
 					isInternetConnected = hasNetwork,
-					homeClickFunctions.onClickedSettingsIcon)
+					homeClickFunctions.onClickedSettingsIcon
+				)
 			}, content = {
 				LazyColumn {
 					item {
@@ -280,25 +336,29 @@ fun HomeScreen(channelsViewModel: ChannelsViewModel,
 							BonusCard(message = homeState.bonuses.first().message,
 								onClickedTC = homeClickFunctions.onClickedTC,
 								onClickedTopUp = {
-									clickedOnBonus(context,
-										channelsViewModel,
-										homeState.bonuses.first())
+									clickedOnBonus(
+										context, channelsViewModel, homeState.bonuses.first()
+									)
 								})
 						}
 					}
 
 					item {
-						PrimaryFeatures(onSendMoneyClicked = homeClickFunctions.onSendMoneyClicked,
+						PrimaryFeatures(
+							onSendMoneyClicked = homeClickFunctions.onSendMoneyClicked,
 							onBuyAirtimeClicked = homeClickFunctions.onBuyAirtimeClicked,
 							onBuyGoodsClicked = homeClickFunctions.onBuyGoodsClicked,
 							onPayBillClicked = homeClickFunctions.onPayBillClicked,
 							onRequestMoneyClicked = homeClickFunctions.onRequestMoneyClicked,
-							showKEFeatures(simCountryList))
+							showKEFeatures(simCountryList)
+						)
 					}
 
 					item {
-						BalanceHeader(onClickedAddAccount = homeClickFunctions.onClickedAddNewAccount,
-							homeState.accounts.isNotEmpty())
+						BalanceHeader(
+							onClickedAddAccount = homeClickFunctions.onClickedAddNewAccount,
+							homeState.accounts.isNotEmpty()
+						)
 
 						if (accounts.isEmpty()) {
 							EmptyBalance(onClickedAddAccount = homeClickFunctions.onClickedAddNewAccount)
@@ -306,9 +366,11 @@ fun HomeScreen(channelsViewModel: ChannelsViewModel,
 					}
 
 					items(accounts) { account ->
-						BalanceItem(staxAccount = account,
+						BalanceItem(
+							staxAccount = account,
 							context = context,
-							balanceTapListener = balanceTapListener)
+							balanceTapListener = balanceTapListener
+						)
 					}
 
 					item {
@@ -316,9 +378,9 @@ fun HomeScreen(channelsViewModel: ChannelsViewModel,
 							!android.text.format.DateUtils.isToday(it.date!!)
 						}?.let {
 							if (homeState.dismissedTipId != it.id) {
-								FinancialTipCard(tipInterface = tipInterface,
-									financialTip = it,
-									homeViewModel)
+								FinancialTipCard(
+									tipInterface = tipInterface, financialTip = it, homeViewModel
+								)
 							}
 						}
 					}
@@ -329,8 +391,9 @@ fun HomeScreen(channelsViewModel: ChannelsViewModel,
 }
 
 private fun clickedOnBonus(context: Context, channelsViewModel: ChannelsViewModel, bonus: Bonus) {
-	AnalyticsUtil.logAnalyticsEvent(context.getString(R.string.clicked_bonus_airtime_banner),
-		context)
+	AnalyticsUtil.logAnalyticsEvent(
+		context.getString(R.string.clicked_bonus_airtime_banner), context
+	)
 	channelsViewModel.validateAccounts(bonus.userChannel)
 }
 
@@ -340,13 +403,15 @@ private fun showKEFeatures(countryIsos: List<String>): Boolean =
 @Preview
 @Composable
 fun HomeScreenPreview() {
-	val financialTip = FinancialTip(id = "1234",
+	val financialTip = FinancialTip(
+		id = "1234",
 		title = "Do you want to save money",
 		content = "This is a test content here so lets see if its going to use ellipse overflow",
 		snippet = "This is a test content here so lets see if its going to use ellipse overflow, with an example here",
 		date = System.currentTimeMillis(),
 		shareCopy = null,
-		deepLink = null)
+		deepLink = null
+	)
 
 	StaxTheme {
 		Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
@@ -365,7 +430,8 @@ fun HomeScreenPreview() {
 							onBuyGoodsClicked = { },
 							onPayBillClicked = { },
 							onRequestMoneyClicked = {},
-							true)
+							true
+						)
 					}
 					item {
 						BalanceScreenPreview()

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
@@ -201,7 +201,7 @@ private fun FinancialTipCard(
                     alignment = Alignment.CenterEnd)
             }
 
-            Row(modifier = Modifier.padding(horizontal = size13)
+            Row(modifier = Modifier.padding(start = size13, end = size13, bottom = size13)
                 .clickable { tipInterface?.onTipClicked(null) }) {
 
                 Column(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeState.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeState.kt
@@ -7,5 +7,6 @@ import com.hover.stax.domain.model.FinancialTip
 data class HomeState (
     val bonuses: List<Bonus> = emptyList(),
     val accounts: List<Account> = emptyList(),
-    val financialTips: List<FinancialTip> = emptyList()
+    val financialTips: List<FinancialTip> = emptyList(),
+    val dismissedTipId: String = ""
 )

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeViewModel.kt
@@ -9,7 +9,7 @@ import com.hover.stax.domain.model.Resource
 import com.hover.stax.domain.use_case.accounts.GetAccountsUseCase
 import com.hover.stax.domain.use_case.bonus.FetchBonusUseCase
 import com.hover.stax.domain.use_case.bonus.GetBonusesUseCase
-import com.hover.stax.domain.use_case.financial_tips.GetTipsUseCase
+import com.hover.stax.domain.use_case.financial_tips.TipsUseCase
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
@@ -17,7 +17,7 @@ class HomeViewModel(
     private val getBonusesUseCase: GetBonusesUseCase,
     private val fetchBonusUseCase: FetchBonusUseCase,
     private val getAccountsUseCase: GetAccountsUseCase,
-    private val getTipsUseCase: GetTipsUseCase
+    private val tipsUseCase: TipsUseCase
 ) : ViewModel() {
 
     private val _homeState = MutableStateFlow(HomeState())
@@ -25,7 +25,6 @@ class HomeViewModel(
 
     private val _accounts = MutableLiveData<List<Account>>()
     val accounts: LiveData<List<Account>> = _accounts
-
 
     init {
         fetchBonuses()
@@ -36,6 +35,7 @@ class HomeViewModel(
         getBonusList()
         getAccounts()
         getFinancialTips()
+        getDismissedFinancialTips()
     }
 
     private fun fetchBonuses() = viewModelScope.launch {
@@ -55,8 +55,16 @@ class HomeViewModel(
         }
     }
 
-    private fun getFinancialTips() = getTipsUseCase().onEach { result ->
+    private fun getFinancialTips() = tipsUseCase().onEach { result ->
         if (result is Resource.Success)
             _homeState.update { it.copy(financialTips = result.data ?: emptyList()) }
     }.launchIn(viewModelScope)
+
+    private fun getDismissedFinancialTips() = _homeState.update { it.copy(dismissedTipId = tipsUseCase.getDismissedTipId() ?: "") }
+    fun dismissTip(id: String) {
+        viewModelScope.launch {
+            tipsUseCase.dismissTip(id)
+           _homeState.update { it.copy(dismissedTipId = id) }
+        }
+    }
 }

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeViewModel.kt
@@ -60,7 +60,10 @@ class HomeViewModel(
             _homeState.update { it.copy(financialTips = result.data ?: emptyList()) }
     }.launchIn(viewModelScope)
 
-    private fun getDismissedFinancialTips() = _homeState.update { it.copy(dismissedTipId = tipsUseCase.getDismissedTipId() ?: "") }
+    private fun getDismissedFinancialTips() = _homeState.update {
+        it.copy(dismissedTipId = tipsUseCase.getDismissedTipId() ?: "")
+    }
+
     fun dismissTip(id: String) {
         viewModelScope.launch {
             tipsUseCase.dismissTip(id)


### PR DESCRIPTION
When the user clicks on the financial-tip close button, it dismisses that tip from home screen throughout the day. 

When visiting the home screen another next day, it shows the new tip, until the user dismisses it.