### PR TITLE
183505442 db migration fixes for 42.json

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,8 +45,8 @@ android {
         applicationId "com.hover.stax"
         minSdk 21
         targetSdk 32
-        versionCode 185
-        versionName "1.14.1"
+        versionCode 186
+        versionName "1.14.2"
 
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true

--- a/app/schemas/com.hover.stax.database.AppDatabase/42.json
+++ b/app/schemas/com.hover.stax.database.AppDatabase/42.json
@@ -76,13 +76,6 @@
             "notNull": true
           },
           {
-            "fieldPath": "institutionType",
-            "columnName": "institution_type",
-            "affinity": "TEXT",
-            "notNull": false,
-            "defaultValue": "'bank'"
-          },
-          {
             "fieldPath": "selected",
             "columnName": "selected",
             "affinity": "INTEGER",
@@ -160,12 +153,6 @@
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
-          },
-          {
-            "fieldPath": "transaction_type",
-            "columnName": "transaction_type",
-            "affinity": "TEXT",
-            "notNull": true
           },
           {
             "fieldPath": "channel_id",

--- a/app/schemas/com.hover.stax.database.AppDatabase/42.json
+++ b/app/schemas/com.hover.stax.database.AppDatabase/42.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 42,
-    "identityHash": "a25697b83a3e9330a87e0df6448dc1df",
+    "identityHash": "62fe5e083b149f16ffcf8f2278853ab6",
     "entities": [
       {
         "tableName": "channels",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, `currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0, `secondary_color_hex` TEXT NOT NULL, `institution_type` TEXT DEFAULT 'bank', `selected` INTEGER NOT NULL DEFAULT 0, `defaultAccount` INTEGER NOT NULL DEFAULT 0, `isFavorite` INTEGER NOT NULL DEFAULT 0, `pin` TEXT, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER DEFAULT CURRENT_TIMESTAMP, `account_no` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, `currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0, `secondary_color_hex` TEXT NOT NULL, `selected` INTEGER NOT NULL DEFAULT 0, `defaultAccount` INTEGER NOT NULL DEFAULT 0, `isFavorite` INTEGER NOT NULL DEFAULT 0, `pin` TEXT, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER DEFAULT CURRENT_TIMESTAMP, `account_no` TEXT, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -153,6 +153,12 @@
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
+          },
+          {
+            "fieldPath": "transaction_type",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
           },
           {
             "fieldPath": "channel_id",
@@ -980,7 +986,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a25697b83a3e9330a87e0df6448dc1df')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '62fe5e083b149f16ffcf8f2278853ab6')"
     ]
   }
 }

--- a/app/src/main/java/com/hover/stax/channels/Channel.java
+++ b/app/src/main/java/com/hover/stax/channels/Channel.java
@@ -62,7 +62,7 @@ public class Channel implements Comparable<Channel> {
     public String secondaryColorHex;
 
     @NonNull
-    @ColumnInfo(name = "institution_type", defaultValue = BANK_TYPE)
+    @ColumnInfo(name = "institution_type")
     public String institutionType;
 
     // Dont use the below, it needs to be removed

--- a/app/src/main/java/com/hover/stax/channels/Channel.java
+++ b/app/src/main/java/com/hover/stax/channels/Channel.java
@@ -61,7 +61,6 @@ public class Channel implements Comparable<Channel> {
     @ColumnInfo(name = "secondary_color_hex")
     public String secondaryColorHex;
 
-    @NonNull
     @ColumnInfo(name = "institution_type", defaultValue = BANK_TYPE)
     public String institutionType;
 
@@ -79,14 +78,16 @@ public class Channel implements Comparable<Channel> {
 
     @ColumnInfo(name = "pin")
     public String pin;
+
     @ColumnInfo(name = "latestBalance")
     public String latestBalance;
+
     @ColumnInfo(name = "latestBalanceTimestamp", defaultValue = "CURRENT_TIMESTAMP")
     public Long latestBalanceTimestamp;
+
     @ColumnInfo(name = "account_no")
     public String accountNo;
-//    @Ignore
-//    public String spentThisMonth, spentDifferenceToLastMonth;
+
 
     public Channel() {
     }

--- a/app/src/main/java/com/hover/stax/channels/Channel.java
+++ b/app/src/main/java/com/hover/stax/channels/Channel.java
@@ -61,6 +61,7 @@ public class Channel implements Comparable<Channel> {
     @ColumnInfo(name = "secondary_color_hex")
     public String secondaryColorHex;
 
+    @NonNull
     @ColumnInfo(name = "institution_type", defaultValue = BANK_TYPE)
     public String institutionType;
 

--- a/app/src/main/java/com/hover/stax/channels/Channel.java
+++ b/app/src/main/java/com/hover/stax/channels/Channel.java
@@ -62,7 +62,7 @@ public class Channel implements Comparable<Channel> {
     public String secondaryColorHex;
 
     @NonNull
-    @ColumnInfo(name = "institution_type")
+    @ColumnInfo(name = "institution_type", defaultValue = BANK_TYPE)
     public String institutionType;
 
     // Dont use the below, it needs to be removed

--- a/app/src/main/java/com/hover/stax/database/AppDatabase.kt
+++ b/app/src/main/java/com/hover/stax/database/AppDatabase.kt
@@ -214,17 +214,11 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_stax_transactions_uuid` ON `stax_transactions` (`uuid`)")
         }
 
-        private val M42_43 = Migration(42, 43) { database -> //accounts table changes
-            database.execSQL("ALTER TABLE channels ADD COLUMN institution_type TEXT NOT NULL DEFAULT 'bank'")
-            database.execSQL("ALTER TABLE accounts ADD COLUMN institution_type TEXT NOT NULL DEFAULT 'bank'")
-            database.execSQL("ALTER TABLE accounts ADD COLUMN sim_subscription_id INTEGER NOT NULL DEFAULT -1")
-        }
-
-
-
-
-        /* When using fallbackToDestructiveMigrationFrom
+        /* By using fallbackToDestructiveMigrationFrom for v42,
+        It drops the V42 table, and creates a new one for v43, hence, no need for migration.
+        This was done because of this conversation: https://hoverup.slack.com/archives/C0DREGYA2/p1665476265215879
         */
+
         fun getInstance(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, "stax.db")
@@ -237,7 +231,5 @@ abstract class AppDatabase : RoomDatabase() {
                 instance
             }
         }
-
-        val VERSION_BEFORE_42_JSON_ERROR = 43
     }
 }

--- a/app/src/main/java/com/hover/stax/database/AppDatabase.kt
+++ b/app/src/main/java/com/hover/stax/database/AppDatabase.kt
@@ -215,6 +215,8 @@ abstract class AppDatabase : RoomDatabase() {
         }
 
         private val M42_43 = Migration(42, 43) { database -> //accounts table changes
+            database.execSQL("ALTER TABLE channels ADD COLUMN institution_type TEXT NOT NULL DEFAULT 'bank'")
+            database.execSQL("ALTER TABLE accounts ADD COLUMN institution_type TEXT NOT NULL DEFAULT 'bank'")
             database.execSQL("ALTER TABLE accounts ADD COLUMN sim_subscription_id INTEGER NOT NULL DEFAULT -1")
         }
 

--- a/app/src/main/java/com/hover/stax/database/AppDatabase.kt
+++ b/app/src/main/java/com/hover/stax/database/AppDatabase.kt
@@ -218,7 +218,7 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL(
                 "CREATE TABLE IF NOT EXISTS `channels_new` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, " +
                         "`currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0," +
-                        "`secondary_color_hex` TEXT NOT NULL, institution_type TEXT DEFAULT 'bank', `selected` INTEGER NOT NULL DEFAULT 0,`defaultAccount` INTEGER NOT NULL DEFAULT 0," +
+                        "`secondary_color_hex` TEXT NOT NULL, institution_type TEXT NOT NULL DEFAULT 'bank', `selected` INTEGER NOT NULL DEFAULT 0,`defaultAccount` INTEGER NOT NULL DEFAULT 0," +
                         "`isFavorite` INTEGER NOT NULL DEFAULT 0, `pin` TEXT, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER DEFAULT CURRENT_TIMESTAMP, `account_no` TEXT)",
             )
 

--- a/app/src/main/java/com/hover/stax/database/AppDatabase.kt
+++ b/app/src/main/java/com/hover/stax/database/AppDatabase.kt
@@ -223,12 +223,14 @@ abstract class AppDatabase : RoomDatabase() {
 
 
 
+        /* When using fallbackToDestructiveMigrationFrom
+        */
         fun getInstance(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, "stax.db")
                     .setJournalMode(JournalMode.WRITE_AHEAD_LOGGING)
-                    .fallbackToDestructiveMigrationFrom(VERSION_BEFORE_42_JSON_ERROR)
-                    .addMigrations(M23_24, M24_25, M25_26, M26_27, M27_28, M28_29, M29_30, M30_31, M31_32, M32_33, M33_34, M34_35, M35_36, M39_40, M42_43)
+                    .fallbackToDestructiveMigrationFrom(42)
+                    .addMigrations(M23_24, M24_25, M25_26, M26_27, M27_28, M28_29, M29_30, M30_31, M31_32, M32_33, M33_34, M34_35, M35_36, M39_40)
                     .build()
                 INSTANCE = instance
 

--- a/app/src/main/java/com/hover/stax/database/AppDatabase.kt
+++ b/app/src/main/java/com/hover/stax/database/AppDatabase.kt
@@ -227,6 +227,7 @@ abstract class AppDatabase : RoomDatabase() {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, "stax.db")
                     .setJournalMode(JournalMode.WRITE_AHEAD_LOGGING)
+                    .fallbackToDestructiveMigrationFrom(VERSION_BEFORE_42_JSON_ERROR)
                     .addMigrations(M23_24, M24_25, M25_26, M26_27, M27_28, M28_29, M29_30, M30_31, M31_32, M32_33, M33_34, M34_35, M35_36, M39_40, M42_43)
                     .build()
                 INSTANCE = instance
@@ -234,5 +235,7 @@ abstract class AppDatabase : RoomDatabase() {
                 instance
             }
         }
+
+        val VERSION_BEFORE_42_JSON_ERROR = 43
     }
 }

--- a/app/src/main/java/com/hover/stax/database/AppDatabase.kt
+++ b/app/src/main/java/com/hover/stax/database/AppDatabase.kt
@@ -219,6 +219,8 @@ abstract class AppDatabase : RoomDatabase() {
         }
 
 
+
+
         fun getInstance(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, "stax.db")


### PR DESCRIPTION
The integrity of 42json changed in development from what it used to be in v1.12.16, it ought to be the same all through.

- I pasted the original content and a few simple refactoring in this fix.
- Added manual migration to drop and recreate channels table so that other tables persist.

I'd be more careful with them in the future.
