### PR TITLE
Depreciate channel fields

### DIFF
--- a/app/schemas/com.hover.stax.database.AppDatabase/42.json
+++ b/app/schemas/com.hover.stax.database.AppDatabase/42.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 42,
-    "identityHash": "a25697b83a3e9330a87e0df6448dc1df",
+    "identityHash": "62fe5e083b149f16ffcf8f2278853ab6",
     "entities": [
       {
         "tableName": "channels",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, `currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0, `secondary_color_hex` TEXT NOT NULL, `institution_type` TEXT DEFAULT 'bank', `selected` INTEGER NOT NULL DEFAULT 0, `defaultAccount` INTEGER NOT NULL DEFAULT 0, `isFavorite` INTEGER NOT NULL DEFAULT 0, `pin` TEXT, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER DEFAULT CURRENT_TIMESTAMP, `account_no` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, `currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0, `secondary_color_hex` TEXT NOT NULL, `selected` INTEGER NOT NULL DEFAULT 0, `defaultAccount` INTEGER NOT NULL DEFAULT 0, `isFavorite` INTEGER NOT NULL DEFAULT 0, `pin` TEXT, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER DEFAULT CURRENT_TIMESTAMP, `account_no` TEXT, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -74,13 +74,6 @@
             "columnName": "secondary_color_hex",
             "affinity": "TEXT",
             "notNull": true
-          },
-          {
-            "fieldPath": "institutionType",
-            "columnName": "institution_type",
-            "affinity": "TEXT",
-            "notNull": false,
-            "defaultValue": "'bank'"
           },
           {
             "fieldPath": "selected",
@@ -993,7 +986,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a25697b83a3e9330a87e0df6448dc1df')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '62fe5e083b149f16ffcf8f2278853ab6')"
     ]
   }
 }

--- a/app/schemas/com.hover.stax.database.AppDatabase/45.json
+++ b/app/schemas/com.hover.stax.database.AppDatabase/45.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 45,
-    "identityHash": "0c31492ca719ab366f0064e74a50652e",
+    "identityHash": "3ff0ec14ddb5ef444155ed236f229f5c",
     "entities": [
       {
         "tableName": "channels",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, `currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0, `secondary_color_hex` TEXT NOT NULL, `institution_type` TEXT NOT NULL DEFAULT 'bank', `selected` INTEGER NOT NULL DEFAULT 0, `defaultAccount` INTEGER NOT NULL DEFAULT 0, `isFavorite` INTEGER NOT NULL DEFAULT 0, `pin` TEXT, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER DEFAULT CURRENT_TIMESTAMP, `account_no` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, `currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0, `secondary_color_hex` TEXT NOT NULL, `institution_type` TEXT NOT NULL DEFAULT 'bank', `isFavorite` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -83,50 +83,11 @@
             "defaultValue": "'bank'"
           },
           {
-            "fieldPath": "selected",
-            "columnName": "selected",
-            "affinity": "INTEGER",
-            "notNull": true,
-            "defaultValue": "0"
-          },
-          {
-            "fieldPath": "defaultAccount",
-            "columnName": "defaultAccount",
-            "affinity": "INTEGER",
-            "notNull": true,
-            "defaultValue": "0"
-          },
-          {
             "fieldPath": "isFavorite",
             "columnName": "isFavorite",
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
-          },
-          {
-            "fieldPath": "pin",
-            "columnName": "pin",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "latestBalance",
-            "columnName": "latestBalance",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "latestBalanceTimestamp",
-            "columnName": "latestBalanceTimestamp",
-            "affinity": "INTEGER",
-            "notNull": false,
-            "defaultValue": "CURRENT_TIMESTAMP"
-          },
-          {
-            "fieldPath": "accountNo",
-            "columnName": "account_no",
-            "affinity": "TEXT",
-            "notNull": false
           }
         ],
         "primaryKey": {
@@ -1014,7 +975,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0c31492ca719ab366f0064e74a50652e')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3ff0ec14ddb5ef444155ed236f229f5c')"
     ]
   }
 }

--- a/app/schemas/com.hover.stax.database.AppDatabase/46.json
+++ b/app/schemas/com.hover.stax.database.AppDatabase/46.json
@@ -1,12 +1,12 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 42,
-    "identityHash": "a25697b83a3e9330a87e0df6448dc1df",
+    "version": 46,
+    "identityHash": "3ff0ec14ddb5ef444155ed236f229f5c",
     "entities": [
       {
         "tableName": "channels",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, `currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0, `secondary_color_hex` TEXT NOT NULL, `institution_type` TEXT DEFAULT 'bank', `selected` INTEGER NOT NULL DEFAULT 0, `defaultAccount` INTEGER NOT NULL DEFAULT 0, `isFavorite` INTEGER NOT NULL DEFAULT 0, `pin` TEXT, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER DEFAULT CURRENT_TIMESTAMP, `account_no` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, `currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0, `secondary_color_hex` TEXT NOT NULL, `institution_type` TEXT NOT NULL DEFAULT 'bank', `isFavorite` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -79,22 +79,8 @@
             "fieldPath": "institutionType",
             "columnName": "institution_type",
             "affinity": "TEXT",
-            "notNull": false,
+            "notNull": true,
             "defaultValue": "'bank'"
-          },
-          {
-            "fieldPath": "selected",
-            "columnName": "selected",
-            "affinity": "INTEGER",
-            "notNull": true,
-            "defaultValue": "0"
-          },
-          {
-            "fieldPath": "defaultAccount",
-            "columnName": "defaultAccount",
-            "affinity": "INTEGER",
-            "notNull": true,
-            "defaultValue": "0"
           },
           {
             "fieldPath": "isFavorite",
@@ -102,31 +88,6 @@
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
-          },
-          {
-            "fieldPath": "pin",
-            "columnName": "pin",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "latestBalance",
-            "columnName": "latestBalance",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "latestBalanceTimestamp",
-            "columnName": "latestBalanceTimestamp",
-            "affinity": "INTEGER",
-            "notNull": false,
-            "defaultValue": "CURRENT_TIMESTAMP"
-          },
-          {
-            "fieldPath": "accountNo",
-            "columnName": "account_no",
-            "affinity": "TEXT",
-            "notNull": false
           }
         ],
         "primaryKey": {
@@ -541,7 +502,7 @@
       },
       {
         "tableName": "accounts",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `alias` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `account_no` TEXT, `institutionId` INTEGER, `countryAlpha2` TEXT, `channelId` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `secondary_color_hex` TEXT NOT NULL, `isDefault` INTEGER NOT NULL DEFAULT 0, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(`channelId`) REFERENCES `channels`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `alias` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `account_no` TEXT, `institutionId` INTEGER, `institution_type` TEXT NOT NULL DEFAULT 'bank', `countryAlpha2` TEXT, `channelId` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `secondary_color_hex` TEXT NOT NULL, `isDefault` INTEGER NOT NULL DEFAULT 0, `sim_subscription_id` INTEGER NOT NULL DEFAULT -1, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(`channelId`) REFERENCES `channels`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
         "fields": [
           {
             "fieldPath": "name",
@@ -574,6 +535,13 @@
             "notNull": false
           },
           {
+            "fieldPath": "institutionType",
+            "columnName": "institution_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'bank'"
+          },
+          {
             "fieldPath": "countryAlpha2",
             "columnName": "countryAlpha2",
             "affinity": "TEXT",
@@ -603,6 +571,13 @@
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
+          },
+          {
+            "fieldPath": "simSubscriptionId",
+            "columnName": "sim_subscription_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
           },
           {
             "fieldPath": "id",
@@ -952,7 +927,7 @@
       },
       {
         "tableName": "bonuses",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_channel` INTEGER NOT NULL, `purchase_channel` INTEGER NOT NULL, `bonus_percent` REAL NOT NULL, `message` TEXT NOT NULL, PRIMARY KEY(`user_channel`, `purchase_channel`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_channel` INTEGER NOT NULL, `purchase_channel` INTEGER NOT NULL, `bonus_percent` REAL NOT NULL, `message` TEXT NOT NULL, `hni_list` TEXT NOT NULL DEFAULT '0', PRIMARY KEY(`user_channel`, `purchase_channel`))",
         "fields": [
           {
             "fieldPath": "userChannel",
@@ -977,6 +952,13 @@
             "columnName": "message",
             "affinity": "TEXT",
             "notNull": true
+          },
+          {
+            "fieldPath": "hniList",
+            "columnName": "hni_list",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
           }
         ],
         "primaryKey": {
@@ -993,7 +975,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a25697b83a3e9330a87e0df6448dc1df')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3ff0ec14ddb5ef444155ed236f229f5c')"
     ]
   }
 }

--- a/app/src/main/java/com/hover/stax/accounts/AccountDetailViewModel.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDetailViewModel.kt
@@ -75,14 +75,6 @@ class AccountDetailViewModel(val application: Application, val repo: AccountRepo
     }
 
     fun removeAccount(account: Account) = viewModelScope.launch(Dispatchers.IO) {
-        val channelsToUpdate = mutableSetOf<Channel>()
-
-        if (repo.getAccountsByChannel(account.channelId).size == 1) {
-            val channel = channelRepo.getChannel(account.channelId)!!
-            channel.selected = false
-            channelsToUpdate.add(channel)
-        }
-
         repo.delete(account)
         transactionRepo.deleteAccountTransactions(account.id)
 
@@ -93,11 +85,6 @@ class AccountDetailViewModel(val application: Application, val repo: AccountRepo
             accounts.firstOrNull()?.let {
                 it.isDefault = true
                 repo.update(it)
-
-                val channel = channelRepo.getChannel(it.channelId)!!
-                channel.selected = true
-                channelsToUpdate.add(channel)
             }
-        channelRepo.update(channelsToUpdate.toList())
     }
 }

--- a/app/src/main/java/com/hover/stax/addChannels/AddChannelsFragment.kt
+++ b/app/src/main/java/com/hover/stax/addChannels/AddChannelsFragment.kt
@@ -162,7 +162,7 @@ class AddChannelsFragment : Fragment(), ChannelsAdapter.SelectListener, CountryA
         binding.channelsListCard.hideProgressIndicator()
 
         if (channels.isNotEmpty()) {
-            updateAdapter(channels.filterNot { it.selected })
+            updateAdapter(channels)
             binding.emptyState.root.visibility = GONE
             binding.channelsList.visibility = VISIBLE
             binding.errorText.visibility = GONE

--- a/app/src/main/java/com/hover/stax/addChannels/ChannelsViewModel.kt
+++ b/app/src/main/java/com/hover/stax/addChannels/ChannelsViewModel.kt
@@ -188,17 +188,13 @@ class ChannelsViewModel(application: Application, val repo: ChannelRepo,
 
         val accounts = channels.mapIndexed { index, channel ->
             val accountName: String = if (getFetchAccountAction(channel.id) == null) channel.name else channel.name.plus(PLACEHOLDER) //ensures uniqueness of name due to db constraints
-            Account(
-                accountName, channel.name, channel.logoUrl, channel.accountNo, channel.id, channel.institutionType, channel.countryAlpha2,
-                channel.id, channel.primaryColorHex, channel.secondaryColorHex, defaultAccount == null && index == 0, simSubscriptionId = -1
-            )
+            Account(accountName, channel, defaultAccount == null && index == 0, -1)
         }.onEach {
             logChoice(it)
             ActionApi.scheduleActionConfigUpdate(it.countryAlpha2, 24, getApplication())
         }
 
         val accountIds = accountRepo.insert(accounts)
-        channels.onEach { it.selected = true }.also { repo.update(it) }
 
         //Refactoring tip: This is currently the only difference when compared with the function in AccountRepositoryImpl.
         promptBalanceCheck(accountIds.first().toInt())

--- a/app/src/main/java/com/hover/stax/channels/Channel.java
+++ b/app/src/main/java/com/hover/stax/channels/Channel.java
@@ -22,6 +22,7 @@ public class Channel implements Comparable<Channel> {
     @PrimaryKey
     @NonNull
     public int id;
+
     @NonNull
     @ColumnInfo(name = "name")
     public String name;
@@ -65,33 +66,11 @@ public class Channel implements Comparable<Channel> {
     @ColumnInfo(name = "institution_type", defaultValue = BANK_TYPE)
     public String institutionType;
 
-    // Dont use the below, it needs to be removed
-    @NonNull
-    @ColumnInfo(name = "selected", defaultValue = "0")
-    public boolean selected;
-    @NonNull
-    @ColumnInfo(name = "defaultAccount", defaultValue = "0")
-    public boolean defaultAccount;
-
     @NonNull
     @ColumnInfo(name = "isFavorite", defaultValue = "0")
     public boolean isFavorite;
 
-    @ColumnInfo(name = "pin")
-    public String pin;
-
-    @ColumnInfo(name = "latestBalance")
-    public String latestBalance;
-
-    @ColumnInfo(name = "latestBalanceTimestamp", defaultValue = "CURRENT_TIMESTAMP")
-    public Long latestBalanceTimestamp;
-
-    @ColumnInfo(name = "account_no")
-    public String accountNo;
-
-
-    public Channel() {
-    }
+    public Channel() {}
 
     public Channel(int _id, String addChannel) {
         this.id = _id;
@@ -100,20 +79,6 @@ public class Channel implements Comparable<Channel> {
 
     public Channel(JSONObject jsonObject, String rootUrl) {
         update(jsonObject, rootUrl);
-    }
-
-    public static List<Channel> sort(List<Channel> channels, boolean showSelected) {
-        ArrayList<Channel> selected_list = new ArrayList<>();
-        ArrayList<Channel> sorted_list = new ArrayList<>();
-        for (Channel c : channels) {
-            if (c.selected) selected_list.add(c);
-            else sorted_list.add(c);
-        }
-        Collections.sort(selected_list);
-        Collections.sort(sorted_list);
-        if (showSelected)
-            sorted_list.addAll(0, selected_list);
-        return sorted_list;
     }
 
     Channel update(JSONObject jsonObject, String rootUrl) {

--- a/app/src/main/java/com/hover/stax/data/local/channels/ChannelDao.kt
+++ b/app/src/main/java/com/hover/stax/data/local/channels/ChannelDao.kt
@@ -20,9 +20,6 @@ interface ChannelDao {
     @get:Query("SELECT * FROM channels WHERE institution_type != 'telecom' ORDER BY name ASC")
     val allChannels: LiveData<List<Channel>>
 
-    @Query("SELECT * FROM channels WHERE selected = :selected AND institution_type != 'telecom' ORDER BY defaultAccount DESC, name ASC")
-    fun getSelected(selected: Boolean): LiveData<List<Channel>>
-
     @Query("SELECT * FROM channels WHERE id IN (:channel_ids) ORDER BY name ASC")
     fun getChannelsByIds(channel_ids: List<Int>): List<Channel>
 
@@ -31,9 +28,6 @@ interface ChannelDao {
 
     @Query("SELECT * FROM channels WHERE country_alpha2 = :countryCode ORDER BY name ASC")
     fun getChannels(countryCode: String): List<Channel>
-
-//    @Query("SELECT * FROM channels WHERE country_alpha2 = :countryCode AND id IN (:channel_ids) ORDER BY name ASC")
-//    fun getChannels(countryCode: String, channel_ids: IntArray): LiveData<List<Channel>>
 
     @Query("SELECT * FROM channels WHERE country_alpha2 = :countryCode AND id IN (:channel_ids) ORDER BY name ASC")
     fun getChannels(countryCode: String, channel_ids: IntArray): List<Channel>
@@ -46,14 +40,6 @@ interface ChannelDao {
 
     @get:Query("SELECT * FROM channels")
     val channels: List<Channel>
-
-    @Transaction
-    @Query("SELECT * FROM channels where selected = 1 AND institution_type != 'telecom' ORDER BY name ASC")
-    fun getChannelsAndAccounts(): List<ChannelWithAccounts>
-
-    @Transaction
-    @Query("SELECT * FROM channels where id = :id ORDER BY name ASC")
-    fun getChannelAndAccounts(id: Int): ChannelWithAccounts?
 
     @get:Query("SELECT COUNT(id) FROM channels")
     val allDataCount: Int

--- a/app/src/main/java/com/hover/stax/data/local/channels/ChannelRepo.kt
+++ b/app/src/main/java/com/hover/stax/data/local/channels/ChannelRepo.kt
@@ -14,8 +14,6 @@ class ChannelRepo(db: AppDatabase) {
     val publishedNonTelecomChannels: LiveData<List<Channel>> = channelDao.publishedNonTelecomChannels
     suspend fun publishedTelecomChannels() : List<Channel> = channelDao.publishedTelecomChannels()
 
-    val selected: LiveData<List<Channel>> = channelDao.getSelected(true)
-
     fun getChannel(id: Int): Channel? { return channelDao.getChannel(id) }
 
     fun getLiveChannel(id: Int): LiveData<Channel> { return channelDao.getLiveChannel(id) }

--- a/app/src/main/java/com/hover/stax/data/repository/AccountRepositoryImpl.kt
+++ b/app/src/main/java/com/hover/stax/data/repository/AccountRepositoryImpl.kt
@@ -39,12 +39,8 @@ class AccountRepositoryImpl(val accountRepo: AccountRepo, val channelRepo: Chann
 
     override suspend fun createAccount(channel: Channel, simSubscriptionId: Int, isDefault: Boolean) {
         val accountName: String = if (getFetchAccountAction(channel.id) == null) channel.name else PLACEHOLDER //placeholder alias for easier identification later
-        val account = Account(
-            accountName, channel.name, channel.logoUrl, channel.accountNo, channel.id, channel.institutionType, channel.countryAlpha2,
-            channel.id, channel.primaryColorHex, channel.secondaryColorHex, isDefault = isDefault, simSubscriptionId = simSubscriptionId
-        )
+        val account = Account(accountName, channel, isDefault, simSubscriptionId)
 
-        channel.selected = true
         channelRepo.update(channel)
         accountRepo.insert(account)
 

--- a/app/src/main/java/com/hover/stax/database/AppDatabase.kt
+++ b/app/src/main/java/com/hover/stax/database/AppDatabase.kt
@@ -36,15 +36,14 @@ import java.util.concurrent.Executors
     entities = [
         Channel::class, StaxTransaction::class, StaxContact::class, Request::class, Schedule::class, Account::class, Paybill::class, Merchant::class, StaxUser::class, Bonus::class
     ],
-    version = 45,
+    version = 46,
     autoMigrations = [
         AutoMigration(from = 36, to = 37),
         AutoMigration(from = 37, to = 38),
         AutoMigration(from = 38, to = 39),
         AutoMigration(from = 40, to = 41),
         AutoMigration(from = 41, to = 42),
-        AutoMigration(from = 43, to = 44),
-        AutoMigration(from = 44, to = 45)
+        AutoMigration(from = 43, to = 44)
     ]
 )
 
@@ -234,11 +233,28 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL("ALTER TABLE accounts ADD COLUMN sim_subscription_id INTEGER NOT NULL DEFAULT -1")
         }
 
+        private val M44_45: Migration = Migration(44, 45) {}
+
+        private val M45_46 = Migration(45, 46) { database -> //accounts table changes
+            database.execSQL(
+                "CREATE TABLE IF NOT EXISTS `channels_new` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, " +
+                        "`currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0," +
+                        "`secondary_color_hex` TEXT NOT NULL, institution_type TEXT NOT NULL DEFAULT 'bank', `isFavorite` INTEGER NOT NULL DEFAULT 0)",
+            )
+
+            database.execSQL(
+                "INSERT INTO channels_new (id, name, country_alpha2, root_code, currency, hni_list, logo_url, institution_id, primary_color_hex, published, secondary_color_hex, isFavorite)" +
+                        " SELECT id, name, country_alpha2, root_code, currency, hni_list, logo_url, institution_id, primary_color_hex, published, secondary_color_hex, isFavorite FROM channels"
+            )
+            database.execSQL("DROP TABLE channels")
+            database.execSQL("ALTER TABLE channels_new RENAME TO channels")
+        }
+
         fun getInstance(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, "stax.db")
                     .setJournalMode(JournalMode.WRITE_AHEAD_LOGGING)
-                    .addMigrations(M23_24, M24_25, M25_26, M26_27, M27_28, M28_29, M29_30, M30_31, M31_32, M32_33, M33_34, M34_35, M35_36, M39_40, M42_43)
+                    .addMigrations(M23_24, M24_25, M25_26, M26_27, M27_28, M28_29, M29_30, M30_31, M31_32, M32_33, M33_34, M34_35, M35_36, M39_40, M42_43, M44_45, M45_46)
                     .build()
                 INSTANCE = instance
 

--- a/app/src/main/java/com/hover/stax/domain/model/Account.kt
+++ b/app/src/main/java/com/hover/stax/domain/model/Account.kt
@@ -57,8 +57,8 @@ data class Account(
 
 ) : Comparable<Account> {
 
-    constructor(name: String, channel: Channel) : this(
-            name, name, channel.logoUrl, "", channel.institutionId, channel.institutionType, channel.countryAlpha2, channel.id, channel.primaryColorHex, channel.secondaryColorHex
+    constructor(name: String, channel: Channel, isDefault: Boolean, simSubscriptionId: Int) : this(
+        name, name, channel.logoUrl, "", channel.institutionId, channel.institutionType, channel.countryAlpha2, channel.id, channel.primaryColorHex, channel.secondaryColorHex, isDefault, simSubscriptionId
     )
 
     constructor(name: String) : this(name, primaryColor = "#292E35")

--- a/app/src/main/java/com/hover/stax/hover/TransactionReceiver.kt
+++ b/app/src/main/java/com/hover/stax/hover/TransactionReceiver.kt
@@ -182,7 +182,7 @@ class TransactionReceiver : BroadcastReceiver(), KoinComponent {
 
         val accounts = ArrayList<Account>()
         while (matcher.find()) {
-            val newAccount = Account(matcher.group(1)!!, channel!!)
+            val newAccount = Account(matcher.group(1)!!, channel!!, false, -1) // FIXME: Need to match this with other accounts to get the right SIM?
             accounts.add(newAccount)
         }
 


### PR DESCRIPTION
There were a number of fields that predate the creation of Accounts. Some of them have been used because the comment saying not to use them is ignored (since that is bad practice anyway). The only user discernible effect of this removal is that we still show selected accounts in the add accounts list. This is how it should be, as users could have multiple accounts connected to different SIM cards. It does still prevent adding a second account however since duplicate account names are not yet allowed.