### PR TITLE
183641255 update firebase BOM to fix crashlytics issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -156,16 +156,15 @@ dependencies {
     implementation 'com.android.installreferrer:installreferrer:2.2'
 
     // Firebase
-    implementation platform('com.google.firebase:firebase-bom:30.3.2')
+    implementation platform('com.google.firebase:firebase-bom:31.0.1')
     implementation 'com.google.firebase:firebase-crashlytics'
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-messaging'
-    implementation 'com.google.firebase:firebase-core'
     implementation 'com.google.firebase:firebase-inappmessaging-display'
     implementation 'com.google.firebase:firebase-config'
-    implementation 'com.google.android.play:core:1.10.3'
     implementation 'com.google.firebase:firebase-perf'
     implementation 'com.google.firebase:firebase-firestore-ktx'
+    implementation 'com.google.android.play:core:1.10.3'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4'
 
     //auth

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,10 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.2'
-        classpath 'com.google.gms:google-services:4.3.13'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.1'
+        classpath 'com.google.gms:google-services:4.3.14'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.firebase:perf-plugin:1.4.1'
+        classpath 'com.google.firebase:perf-plugin:1.4.2'
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@ org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M" -XX\:+UseP
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.vfs.watch=true
+


### PR DESCRIPTION
When we login into the Crashlytics dashboard, there's an urgent notice for developers to update the library.

- Rearranged play_core library positioning for clarity.
- Update build dependencies.

- This update [deprecates firebase-core](https://firebase.google.com/support/release-notes/android#:~:text=BREAKING%20CHANGE%3A%20With%20this%20release%2C%20the%20BoM%20no%20longer%20contains%20the%20following%20deprecated%20libraries%3A%0Afirebase%2Dappindexing%2C%20firebase%2Dcore%2C%20and%20firebase%2Diid.%20Use%20the%20following%20alternatives%20instead%3A): 