### PR TITLE
Likely fix for recipient network logo not refreshing/resetting

### DIFF
--- a/app/src/main/java/com/hover/stax/accounts/AccountDropdown.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDropdown.kt
@@ -25,6 +25,16 @@ class AccountDropdown(context: Context, attributeSet: AttributeSet) : StaxDropdo
 
     private var highlightedAccount: Account? = null
 
+    val target = object : CustomTarget<Drawable>() {
+        override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
+            autoCompleteTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(resource, null, null, null)
+        }
+
+        override fun onLoadCleared(placeholder: Drawable?) {
+            autoCompleteTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_grey_circle_small, 0, 0, 0)
+        }
+    }
+
     init {
         getAttrs(context, attributeSet)
     }
@@ -54,22 +64,11 @@ class AccountDropdown(context: Context, attributeSet: AttributeSet) : StaxDropdo
     }
 
     private fun setDropdownValue(account: Account?) {
-        account?.let {
-            autoCompleteTextView.setText(it.alias, false)
-
-            val target = object : CustomTarget<Drawable>() {
-                override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
-                    autoCompleteTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(resource, null, null, null)
-                }
-
-                override fun onLoadCleared(placeholder: Drawable?) {
-                    autoCompleteTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.ic_grey_circle_small, 0, 0, 0)
-                }
-            }
-
+        if (account != null) {
             UIHelper.loadImage(context, account.logoUrl, target)
+            autoCompleteTextView.setText(account.alias, false)
             highlightedAccount = account
-        }
+        } else { UIHelper.loadImage(context, null, target)}
     }
 
     private fun updateChoices(accounts: List<Account>) {

--- a/app/src/main/java/com/hover/stax/utils/UIHelper.kt
+++ b/app/src/main/java/com/hover/stax/utils/UIHelper.kt
@@ -105,7 +105,7 @@ object UIHelper {
         .circleCrop()
         .into(this)
 
-    fun loadImage(context: Context, url: String, target: CustomTarget<Drawable>) = GlideApp.with(context)
+    fun loadImage(context: Context, url: String?, target: CustomTarget<Drawable>) = GlideApp.with(context)
         .load(url)
         .placeholder(R.drawable.icon_bg_circle)
         .circleCrop()


### PR DESCRIPTION
I am unable to reproduce the issue. However, it is likely that every time the dropdown was updated a new target was being created, leaving the old one hanging. Now only creates one target per dropdown instance.