### PR TITLE
Remove fetch accounts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -203,7 +203,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
     // Hover SDK
-    def sdk_version = "2.0.0-stax-1.17.0-pro"
+    def sdk_version = "2.0.0-stax-1.17.1-pro"
     releaseImplementation "com.hover:android-sdk:$sdk_version"
     debugImplementation project(":hover.sdk")
     debugImplementation 'com.android.volley:volley:1.2.1'

--- a/app/schemas/com.hover.stax.database.AppDatabase/47.json
+++ b/app/schemas/com.hover.stax.database.AppDatabase/47.json
@@ -1,0 +1,988 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 47,
+    "identityHash": "eece2fa9fa5ef8d9dbdd43c89ce58acb",
+    "entities": [
+      {
+        "tableName": "channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, `currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0, `secondary_color_hex` TEXT NOT NULL, `institution_type` TEXT NOT NULL DEFAULT 'bank', `isFavorite` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryAlpha2",
+            "columnName": "country_alpha2",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootCode",
+            "columnName": "root_code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hniList",
+            "columnName": "hni_list",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logo_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "institutionId",
+            "columnName": "institution_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryColorHex",
+            "columnName": "primary_color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "published",
+            "columnName": "published",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "secondaryColorHex",
+            "columnName": "secondary_color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "institutionType",
+            "columnName": "institution_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'bank'"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "stax_transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `action_id` TEXT NOT NULL, `environment` INTEGER NOT NULL DEFAULT 0, `transaction_type` TEXT NOT NULL, `channel_id` INTEGER NOT NULL, `status` TEXT NOT NULL DEFAULT 'pending', `category` TEXT NOT NULL DEFAULT 'started', `initiated_at` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `description` TEXT NOT NULL, `account_id` INTEGER, `recipient_id` TEXT, `amount` REAL, `fee` REAL, `confirm_code` TEXT, `balance` TEXT, `note` TEXT, `counterparty` TEXT, `account_name` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "action_id",
+            "columnName": "action_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "environment",
+            "columnName": "environment",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "transaction_type",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channel_id",
+            "columnName": "channel_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'pending'"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'started'"
+          },
+          {
+            "fieldPath": "initiated_at",
+            "columnName": "initiated_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          },
+          {
+            "fieldPath": "updated_at",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "counterparty_id",
+            "columnName": "recipient_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fee",
+            "columnName": "fee",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "confirm_code",
+            "columnName": "confirm_code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "counterpartyNo",
+            "columnName": "counterparty",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountName",
+            "columnName": "account_name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_stax_transactions_uuid",
+            "unique": true,
+            "columnNames": [
+              "uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stax_transactions_uuid` ON `${TABLE_NAME}` (`uuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "stax_contacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `lookup_key` TEXT, `name` TEXT, `aliases` TEXT, `phone_number` TEXT, `thumb_uri` TEXT, `last_used_timestamp` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lookupKey",
+            "columnName": "lookup_key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "aliases",
+            "columnName": "aliases",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "phone_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbUri",
+            "columnName": "thumb_uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUsedTimestamp",
+            "columnName": "last_used_timestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_stax_contacts_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stax_contacts_id` ON `${TABLE_NAME}` (`id`)"
+          },
+          {
+            "name": "index_stax_contacts_phone_number",
+            "unique": true,
+            "columnNames": [
+              "phone_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stax_contacts_phone_number` ON `${TABLE_NAME}` (`phone_number`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "requests",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `description` TEXT, `requestee_ids` TEXT NOT NULL, `amount` TEXT, `requester_institution_id` INTEGER NOT NULL DEFAULT 0, `requester_number` TEXT, `requester_country_alpha2` TEXT, `note` TEXT, `message` TEXT, `matched_transaction_uuid` TEXT, `requester_account_id` INTEGER, `date_sent` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "requestee_ids",
+            "columnName": "requestee_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "requester_institution_id",
+            "columnName": "requester_institution_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "requester_number",
+            "columnName": "requester_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "requester_country_alpha2",
+            "columnName": "requester_country_alpha2",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "matched_transaction_uuid",
+            "columnName": "matched_transaction_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "requester_account_id",
+            "columnName": "requester_account_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "date_sent",
+            "columnName": "date_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "schedules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `channel_id` INTEGER NOT NULL, `action_id` TEXT, `recipient_ids` TEXT NOT NULL, `amount` TEXT, `note` TEXT, `description` TEXT NOT NULL, `start_date` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, `end_date` INTEGER DEFAULT CURRENT_TIMESTAMP, `frequency` INTEGER NOT NULL, `complete` INTEGER NOT NULL DEFAULT false)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channel_id",
+            "columnName": "channel_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "action_id",
+            "columnName": "action_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recipient_ids",
+            "columnName": "recipient_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "start_date",
+            "columnName": "start_date",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          },
+          {
+            "fieldPath": "end_date",
+            "columnName": "end_date",
+            "affinity": "INTEGER",
+            "notNull": false,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          },
+          {
+            "fieldPath": "frequency",
+            "columnName": "frequency",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "complete",
+            "columnName": "complete",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "accounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `alias` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `account_no` TEXT, `institutionId` INTEGER, `institution_type` TEXT NOT NULL DEFAULT 'bank', `countryAlpha2` TEXT, `channelId` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `secondary_color_hex` TEXT NOT NULL, `isDefault` INTEGER NOT NULL DEFAULT 0, `sim_subscription_id` INTEGER NOT NULL DEFAULT -1, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `institutionAccountName` TEXT, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(`channelId`) REFERENCES `channels`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "institutionName",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAlias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logo_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountNo",
+            "columnName": "account_no",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "institutionId",
+            "columnName": "institutionId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "institutionType",
+            "columnName": "institution_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'bank'"
+          },
+          {
+            "fieldPath": "countryAlpha2",
+            "columnName": "countryAlpha2",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryColorHex",
+            "columnName": "primary_color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secondaryColorHex",
+            "columnName": "secondary_color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "simSubscriptionId",
+            "columnName": "sim_subscription_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "institutionAccountName",
+            "columnName": "institutionAccountName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latestBalance",
+            "columnName": "latestBalance",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latestBalanceTimestamp",
+            "columnName": "latestBalanceTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_accounts_name_sim_subscription_id",
+            "unique": true,
+            "columnNames": [
+              "name",
+              "sim_subscription_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_accounts_name_sim_subscription_id` ON `${TABLE_NAME}` (`name`, `sim_subscription_id`)"
+          },
+          {
+            "name": "index_accounts_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_accounts_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "channels",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "channelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "paybills",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `business_name` TEXT, `business_no` TEXT, `account_no` TEXT, `action_id` TEXT DEFAULT '', `accountId` INTEGER NOT NULL, `logo_url` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recurring_amount` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `logo` INTEGER NOT NULL, `isSaved` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`channelId`) REFERENCES `channels`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`accountId`) REFERENCES `accounts`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "businessName",
+            "columnName": "business_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "businessNo",
+            "columnName": "business_no",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountNo",
+            "columnName": "account_no",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "actionId",
+            "columnName": "action_id",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logo_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recurringAmount",
+            "columnName": "recurring_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logo",
+            "columnName": "logo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSaved",
+            "columnName": "isSaved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_paybills_business_no_account_no",
+            "unique": true,
+            "columnNames": [
+              "business_no",
+              "account_no"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_paybills_business_no_account_no` ON `${TABLE_NAME}` (`business_no`, `account_no`)"
+          },
+          {
+            "name": "index_paybills_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_paybills_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_paybills_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_paybills_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "channels",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "channelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "accounts",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "merchants",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`business_name` TEXT, `till_no` TEXT NOT NULL, `action_id` TEXT DEFAULT '', `accountId` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `last_used_timestamp` INTEGER, FOREIGN KEY(`channelId`) REFERENCES `channels`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "businessName",
+            "columnName": "business_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tillNo",
+            "columnName": "till_no",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionId",
+            "columnName": "action_id",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedTimestamp",
+            "columnName": "last_used_timestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_merchants_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_merchants_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_merchants_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_merchants_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "channels",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "channelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stax_users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `username` TEXT NOT NULL, `email` TEXT NOT NULL, `isMapper` INTEGER NOT NULL DEFAULT 0, `marketingOptedIn` INTEGER NOT NULL DEFAULT 0, `transactionCount` INTEGER NOT NULL, `bountyTotal` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMapper",
+            "columnName": "isMapper",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "marketingOptedIn",
+            "columnName": "marketingOptedIn",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "transactionCount",
+            "columnName": "transactionCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bountyTotal",
+            "columnName": "bountyTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "bonuses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_channel` INTEGER NOT NULL, `purchase_channel` INTEGER NOT NULL, `bonus_percent` REAL NOT NULL, `message` TEXT NOT NULL, `hni_list` TEXT NOT NULL DEFAULT '0', PRIMARY KEY(`user_channel`, `purchase_channel`))",
+        "fields": [
+          {
+            "fieldPath": "userChannel",
+            "columnName": "user_channel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "purchaseChannel",
+            "columnName": "purchase_channel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bonusPercent",
+            "columnName": "bonus_percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hniList",
+            "columnName": "hni_list",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "user_channel",
+            "purchase_channel"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'eece2fa9fa5ef8d9dbdd43c89ce58acb')"
+    ]
+  }
+}

--- a/app/schemas/com.hover.stax.database.AppDatabase/48.json
+++ b/app/schemas/com.hover.stax.database.AppDatabase/48.json
@@ -1,0 +1,988 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 48,
+    "identityHash": "eece2fa9fa5ef8d9dbdd43c89ce58acb",
+    "entities": [
+      {
+        "tableName": "channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, `currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0, `secondary_color_hex` TEXT NOT NULL, `institution_type` TEXT NOT NULL DEFAULT 'bank', `isFavorite` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countryAlpha2",
+            "columnName": "country_alpha2",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootCode",
+            "columnName": "root_code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hniList",
+            "columnName": "hni_list",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logo_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "institutionId",
+            "columnName": "institution_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryColorHex",
+            "columnName": "primary_color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "published",
+            "columnName": "published",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "secondaryColorHex",
+            "columnName": "secondary_color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "institutionType",
+            "columnName": "institution_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'bank'"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "stax_transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `action_id` TEXT NOT NULL, `environment` INTEGER NOT NULL DEFAULT 0, `transaction_type` TEXT NOT NULL, `channel_id` INTEGER NOT NULL, `status` TEXT NOT NULL DEFAULT 'pending', `category` TEXT NOT NULL DEFAULT 'started', `initiated_at` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `description` TEXT NOT NULL, `account_id` INTEGER, `recipient_id` TEXT, `amount` REAL, `fee` REAL, `confirm_code` TEXT, `balance` TEXT, `note` TEXT, `counterparty` TEXT, `account_name` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "action_id",
+            "columnName": "action_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "environment",
+            "columnName": "environment",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "transaction_type",
+            "columnName": "transaction_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channel_id",
+            "columnName": "channel_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'pending'"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'started'"
+          },
+          {
+            "fieldPath": "initiated_at",
+            "columnName": "initiated_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          },
+          {
+            "fieldPath": "updated_at",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "counterparty_id",
+            "columnName": "recipient_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fee",
+            "columnName": "fee",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "confirm_code",
+            "columnName": "confirm_code",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "counterpartyNo",
+            "columnName": "counterparty",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountName",
+            "columnName": "account_name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_stax_transactions_uuid",
+            "unique": true,
+            "columnNames": [
+              "uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stax_transactions_uuid` ON `${TABLE_NAME}` (`uuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "stax_contacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `lookup_key` TEXT, `name` TEXT, `aliases` TEXT, `phone_number` TEXT, `thumb_uri` TEXT, `last_used_timestamp` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lookupKey",
+            "columnName": "lookup_key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "aliases",
+            "columnName": "aliases",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountNumber",
+            "columnName": "phone_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "thumbUri",
+            "columnName": "thumb_uri",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUsedTimestamp",
+            "columnName": "last_used_timestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_stax_contacts_id",
+            "unique": true,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stax_contacts_id` ON `${TABLE_NAME}` (`id`)"
+          },
+          {
+            "name": "index_stax_contacts_phone_number",
+            "unique": true,
+            "columnNames": [
+              "phone_number"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_stax_contacts_phone_number` ON `${TABLE_NAME}` (`phone_number`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "requests",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `description` TEXT, `requestee_ids` TEXT NOT NULL, `amount` TEXT, `requester_institution_id` INTEGER NOT NULL DEFAULT 0, `requester_number` TEXT, `requester_country_alpha2` TEXT, `note` TEXT, `message` TEXT, `matched_transaction_uuid` TEXT, `requester_account_id` INTEGER, `date_sent` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "requestee_ids",
+            "columnName": "requestee_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "requester_institution_id",
+            "columnName": "requester_institution_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "requester_number",
+            "columnName": "requester_number",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "requester_country_alpha2",
+            "columnName": "requester_country_alpha2",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "matched_transaction_uuid",
+            "columnName": "matched_transaction_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "requester_account_id",
+            "columnName": "requester_account_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "date_sent",
+            "columnName": "date_sent",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "schedules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `channel_id` INTEGER NOT NULL, `action_id` TEXT, `recipient_ids` TEXT NOT NULL, `amount` TEXT, `note` TEXT, `description` TEXT NOT NULL, `start_date` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, `end_date` INTEGER DEFAULT CURRENT_TIMESTAMP, `frequency` INTEGER NOT NULL, `complete` INTEGER NOT NULL DEFAULT false)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channel_id",
+            "columnName": "channel_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "action_id",
+            "columnName": "action_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recipient_ids",
+            "columnName": "recipient_ids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "start_date",
+            "columnName": "start_date",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          },
+          {
+            "fieldPath": "end_date",
+            "columnName": "end_date",
+            "affinity": "INTEGER",
+            "notNull": false,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          },
+          {
+            "fieldPath": "frequency",
+            "columnName": "frequency",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "complete",
+            "columnName": "complete",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "accounts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `alias` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `account_no` TEXT, `institutionId` INTEGER, `institution_type` TEXT NOT NULL DEFAULT 'bank', `countryAlpha2` TEXT, `channelId` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `secondary_color_hex` TEXT NOT NULL, `isDefault` INTEGER NOT NULL DEFAULT 0, `sim_subscription_id` INTEGER NOT NULL DEFAULT -1, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `institutionAccountName` TEXT, `latestBalance` TEXT, `latestBalanceTimestamp` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, FOREIGN KEY(`channelId`) REFERENCES `channels`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "institutionName",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userAlias",
+            "columnName": "alias",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logo_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountNo",
+            "columnName": "account_no",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "institutionId",
+            "columnName": "institutionId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "institutionType",
+            "columnName": "institution_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'bank'"
+          },
+          {
+            "fieldPath": "countryAlpha2",
+            "columnName": "countryAlpha2",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryColorHex",
+            "columnName": "primary_color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secondaryColorHex",
+            "columnName": "secondary_color_hex",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "simSubscriptionId",
+            "columnName": "sim_subscription_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "institutionAccountName",
+            "columnName": "institutionAccountName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latestBalance",
+            "columnName": "latestBalance",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latestBalanceTimestamp",
+            "columnName": "latestBalanceTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_accounts_name_sim_subscription_id",
+            "unique": true,
+            "columnNames": [
+              "name",
+              "sim_subscription_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_accounts_name_sim_subscription_id` ON `${TABLE_NAME}` (`name`, `sim_subscription_id`)"
+          },
+          {
+            "name": "index_accounts_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_accounts_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "channels",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "channelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "paybills",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `business_name` TEXT, `business_no` TEXT, `account_no` TEXT, `action_id` TEXT DEFAULT '', `accountId` INTEGER NOT NULL, `logo_url` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recurring_amount` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `logo` INTEGER NOT NULL, `isSaved` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`channelId`) REFERENCES `channels`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`accountId`) REFERENCES `accounts`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "businessName",
+            "columnName": "business_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "businessNo",
+            "columnName": "business_no",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accountNo",
+            "columnName": "account_no",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "actionId",
+            "columnName": "action_id",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logoUrl",
+            "columnName": "logo_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recurringAmount",
+            "columnName": "recurring_amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "logo",
+            "columnName": "logo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSaved",
+            "columnName": "isSaved",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_paybills_business_no_account_no",
+            "unique": true,
+            "columnNames": [
+              "business_no",
+              "account_no"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_paybills_business_no_account_no` ON `${TABLE_NAME}` (`business_no`, `account_no`)"
+          },
+          {
+            "name": "index_paybills_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_paybills_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_paybills_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_paybills_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "channels",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "channelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "accounts",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "merchants",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`business_name` TEXT, `till_no` TEXT NOT NULL, `action_id` TEXT DEFAULT '', `accountId` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `last_used_timestamp` INTEGER, FOREIGN KEY(`channelId`) REFERENCES `channels`(`id`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "businessName",
+            "columnName": "business_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tillNo",
+            "columnName": "till_no",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionId",
+            "columnName": "action_id",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedTimestamp",
+            "columnName": "last_used_timestamp",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_merchants_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_merchants_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_merchants_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_merchants_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "channels",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "channelId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "stax_users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `username` TEXT NOT NULL, `email` TEXT NOT NULL, `isMapper` INTEGER NOT NULL DEFAULT 0, `marketingOptedIn` INTEGER NOT NULL DEFAULT 0, `transactionCount` INTEGER NOT NULL, `bountyTotal` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMapper",
+            "columnName": "isMapper",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "marketingOptedIn",
+            "columnName": "marketingOptedIn",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "transactionCount",
+            "columnName": "transactionCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bountyTotal",
+            "columnName": "bountyTotal",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "bonuses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_channel` INTEGER NOT NULL, `purchase_channel` INTEGER NOT NULL, `bonus_percent` REAL NOT NULL, `message` TEXT NOT NULL, `hni_list` TEXT NOT NULL DEFAULT '0', PRIMARY KEY(`user_channel`, `purchase_channel`))",
+        "fields": [
+          {
+            "fieldPath": "userChannel",
+            "columnName": "user_channel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "purchaseChannel",
+            "columnName": "purchase_channel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bonusPercent",
+            "columnName": "bonus_percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hniList",
+            "columnName": "hni_list",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "user_channel",
+            "purchase_channel"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'eece2fa9fa5ef8d9dbdd43c89ce58acb')"
+    ]
+  }
+}

--- a/app/src/main/java/com/hover/stax/accounts/AccountDetailFragment.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDetailFragment.kt
@@ -18,7 +18,6 @@ import com.hover.stax.R
 import com.hover.stax.presentation.home.BalancesViewModel
 import com.hover.stax.databinding.FragmentAccountBinding
 import com.hover.stax.domain.model.Account
-import com.hover.stax.domain.model.PLACEHOLDER
 import com.hover.stax.futureTransactions.FutureViewModel
 import com.hover.stax.futureTransactions.RequestsAdapter
 import com.hover.stax.futureTransactions.ScheduledAdapter
@@ -87,7 +86,7 @@ class AccountDetailFragment : Fragment(), TransactionHistoryAdapter.SelectListen
         override fun beforeTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {}
         override fun afterTextChanged(editable: Editable) {}
         override fun onTextChanged(charSequence: CharSequence, i: Int, i1: Int, i2: Int) {
-            toggleButtonHighlight(binding.manageCard.nicknameInput, binding.manageCard.nicknameSaveBtn, charSequence.toString(), viewModel.account.value?.alias)
+            toggleButtonHighlight(binding.manageCard.nicknameInput, binding.manageCard.nicknameSaveBtn, charSequence.toString(), viewModel.account.value?.userAlias)
         }
     }
 
@@ -110,7 +109,7 @@ class AccountDetailFragment : Fragment(), TransactionHistoryAdapter.SelectListen
     }
 
     private fun updateNickname() {
-        validateInput(binding.manageCard.nicknameInput, viewModel.account.value?.alias, R.string.account_name_error, viewModel::updateAccountName)
+        validateInput(binding.manageCard.nicknameInput, viewModel.account.value?.userAlias, R.string.account_name_error, viewModel::updateAccountName)
     }
 
     private fun updateAccountNumber() {
@@ -138,16 +137,18 @@ class AccountDetailFragment : Fragment(), TransactionHistoryAdapter.SelectListen
         with(viewModel) {
             account.observe(viewLifecycleOwner) {
                 it?.let { acct ->
-                    binding.amountsCard.setTitle(acct.alias)
+                    binding.amountsCard.setTitle(acct.userAlias)
+                    if (acct.userAlias != acct.institutionName)
+                        binding.amountsCard.setSubtitle(acct.institutionName)
                     if (acct.latestBalance != null) {
                         binding.balanceCard.balanceAmount.text = acct.latestBalance
                         binding.balanceCard.balanceSubtitle.text = DateUtils.humanFriendlyDateTime(acct.latestBalanceTimestamp)
                     } else binding.balanceCard.balanceSubtitle.text = getString(R.string.refresh_balance_desc)
 
-                    binding.feesDescription.text = getString(R.string.fees_label, acct.name)
-                    binding.detailsCard.officialName.text = if(acct.name.contains(PLACEHOLDER)) acct.alias else acct.name
+                    binding.feesDescription.text = getString(R.string.fees_label, acct.institutionName)
+                    binding.detailsCard.officialName.text = acct.userAlias
 
-                    binding.manageCard.nicknameInput.setText(acct.alias, false)
+                    binding.manageCard.nicknameInput.setText(acct.userAlias, false)
                     binding.manageCard.accountNumberInput.setText(acct.accountNo, false)
                     binding.manageCard.removeAcctBtn.setOnClickListener { setUpRemoveAccount(acct) }
 
@@ -156,8 +157,6 @@ class AccountDetailFragment : Fragment(), TransactionHistoryAdapter.SelectListen
             }
 
             channel.observe(viewLifecycleOwner) { c ->
-                if (account.value != null && account.value!!.alias != c.name)
-                    binding.amountsCard.setSubtitle(c.name)
                 binding.detailsCard.shortcodeBtn.text = getString(R.string.dial_btn, c.rootCode)
                 binding.detailsCard.shortcodeBtn.setOnClickListener { Utils.dial(c.rootCode, requireContext()) }
             }
@@ -197,7 +196,7 @@ class AccountDetailFragment : Fragment(), TransactionHistoryAdapter.SelectListen
 
     private fun setUpRemoveAccount(account: Account) {
         dialog = StaxDialog(requireActivity())
-                .setDialogTitle(getString(R.string.removeaccount_dialoghead, account.alias))
+                .setDialogTitle(getString(R.string.removeaccount_dialoghead, account.userAlias))
                 .setDialogMessage(R.string.removeaccount_msg)
                 .setPosButton(R.string.btn_removeaccount) { removeAccount(account) }
                 .setNegButton(R.string.btn_cancel, null)

--- a/app/src/main/java/com/hover/stax/accounts/AccountDetailViewModel.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDetailViewModel.kt
@@ -50,7 +50,7 @@ class AccountDetailViewModel(val application: Application, val repo: AccountRepo
 
     fun updateAccountName(newName: String) = viewModelScope.launch(Dispatchers.IO) {
         val a = account.value!!
-        a.alias = newName
+        a.userAlias = newName
         repo.update(a)
     }
 

--- a/app/src/main/java/com/hover/stax/accounts/AccountDropdown.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDropdown.kt
@@ -66,7 +66,7 @@ class AccountDropdown(context: Context, attributeSet: AttributeSet) : StaxDropdo
     private fun setDropdownValue(account: Account?) {
         if (account != null) {
             UIHelper.loadImage(context, account.logoUrl, target)
-            autoCompleteTextView.setText(account.alias, false)
+            autoCompleteTextView.setText(account.userAlias, false)
             highlightedAccount = account
         } else { UIHelper.loadImage(context, null, target)}
     }

--- a/app/src/main/java/com/hover/stax/accounts/AccountDropdownAdapter.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountDropdownAdapter.kt
@@ -39,7 +39,7 @@ class AccountDropdownAdapter(val accounts: List<Account>, context: Context) : Ar
     inner class ViewHolder(val binding: StaxSpinnerItemWithLogoBinding) {
 
         fun setAccount(account: Account) {
-            binding.serviceItemNameId.text = account.alias
+            binding.serviceItemNameId.text = account.userAlias
 
             if (account.logoUrl.isEmpty())
                 binding.serviceItemImageId.loadImage(binding.root.context, R.drawable.ic_add)

--- a/app/src/main/java/com/hover/stax/accounts/AccountsAdapter.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountsAdapter.kt
@@ -29,7 +29,7 @@ class AccountsAdapter(var accounts: List<Account>) : RecyclerView.Adapter<Accoun
     inner class ViewHolder(val binding: StaxSpinnerItemWithLogoBinding) : RecyclerView.ViewHolder(binding.root) {
 
         fun setAccount(account: Account) {
-            binding.serviceItemNameId.text = account.alias
+            binding.serviceItemNameId.text = account.userAlias
 
             GlideApp.with(binding.root.context)
                 .load(account.logoUrl)

--- a/app/src/main/java/com/hover/stax/accounts/AccountsViewModel.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountsViewModel.kt
@@ -8,7 +8,6 @@ import com.hover.stax.R
 import com.hover.stax.data.local.accounts.AccountRepo
 import com.hover.stax.data.local.actions.ActionRepo
 import com.hover.stax.domain.model.Account
-import com.hover.stax.domain.model.PLACEHOLDER
 import com.hover.stax.schedules.Schedule
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -101,7 +100,7 @@ class AccountsViewModel(application: Application, val repo: AccountRepo, val act
         }
     }
 
-    fun isValidAccount(): Boolean = !activeAccount.value!!.name.contains(PLACEHOLDER)
+    fun isValidAccount(): Boolean = activeAccount.value?.latestBalance != null || activeAccount.value?.institutionType != "bank"
 
     fun view(s: Schedule) {
         setType(s.type)
@@ -126,7 +125,7 @@ class AccountsViewModel(application: Application, val repo: AccountRepo, val act
             a.isDefault = true
             repo.update(a)
 
-            accountUpdateChannel.send((getApplication() as Context).getString(R.string.def_account_update_msg, account.alias))
+            accountUpdateChannel.send((getApplication() as Context).getString(R.string.def_account_update_msg, account.userAlias))
         }
     }
 

--- a/app/src/main/java/com/hover/stax/addChannels/ChannelsViewModel.kt
+++ b/app/src/main/java/com/hover/stax/addChannels/ChannelsViewModel.kt
@@ -21,7 +21,6 @@ import com.hover.stax.channels.Channel
 import com.hover.stax.data.local.channels.ChannelRepo
 import com.hover.stax.countries.CountryAdapter
 import com.hover.stax.data.local.SimRepo
-import com.hover.stax.domain.model.PLACEHOLDER
 import com.hover.stax.notifications.PushNotificationTopicsInterface
 import com.hover.stax.utils.AnalyticsUtil
 import com.hover.stax.utils.Utils
@@ -187,8 +186,7 @@ class ChannelsViewModel(application: Application, val repo: ChannelRepo,
         val defaultAccount = accountRepo.getDefaultAccount()
 
         val accounts = channels.mapIndexed { index, channel ->
-            val accountName: String = if (getFetchAccountAction(channel.id) == null) channel.name else channel.name.plus(PLACEHOLDER) //ensures uniqueness of name due to db constraints
-            Account(accountName, channel, defaultAccount == null && index == 0, -1)
+            Account(channel, defaultAccount == null && index == 0, -1)
         }.onEach {
             logChoice(it)
             ActionApi.scheduleActionConfigUpdate(it.countryAlpha2, 24, getApplication())
@@ -207,8 +205,6 @@ class ChannelsViewModel(application: Application, val repo: ChannelRepo,
             accountChannel.send(it)
         }
     }
-
-    private fun getFetchAccountAction(channelId: Int): HoverAction? = actionRepo.getActions(channelId, HoverAction.FETCH_ACCOUNTS).firstOrNull()
 
     fun updateSearch(value: String) {
         filterQuery.value = value

--- a/app/src/main/java/com/hover/stax/data/local/accounts/AccountRepo.kt
+++ b/app/src/main/java/com/hover/stax/data/local/accounts/AccountRepo.kt
@@ -29,21 +29,11 @@ class AccountRepo(db: AppDatabase) {
 
     fun getAccounts(): Flow<List<Account>> = accountDao.getAccounts()
 
-    private fun getAccount(name: String, channelId: Int): Account? = accountDao.getAccount(name, channelId)
-
-    fun saveAccounts(accounts: List<Account>) {
-        accounts.forEach { account ->
-            val acct = getAccount(account.name, account.channelId)
-
-            try {
-                if (acct == null) {
-                    accountDao.insert(account)
-                } else {
-                    accountDao.update(account)
-                }
-            } catch (e: Exception) {
-                AnalyticsUtil.logErrorAndReportToFirebase(TAG, "failed to insert/update account", e)
-            }
+    fun saveAccount(account: Account) {
+        if (account.id == 0) {
+            accountDao.insert(account)
+        } else {
+            accountDao.update(account)
         }
     }
 
@@ -56,10 +46,6 @@ class AccountRepo(db: AppDatabase) {
     suspend fun update(accounts: List<Account>) = accountDao.updateAll(accounts)
 
     fun delete(account: Account) = accountDao.delete(account)
-
-    fun deleteAccount(channelId: Int, name: String) {
-        accountDao.delete(channelId, name)
-    }
 
     companion object {
         private val TAG = AccountRepo::class.java.simpleName

--- a/app/src/main/java/com/hover/stax/data/local/actions/ActionRepo.kt
+++ b/app/src/main/java/com/hover/stax/data/local/actions/ActionRepo.kt
@@ -37,10 +37,6 @@ class ActionRepo(sdkDb: HoverRoomDatabase) {
         return actionDao.getActions(channelId, type)
     }
 
-    fun getActions(channelIds: IntArray?, type: String?): List<HoverAction> {
-        return actionDao.getActions(channelIds, type)
-    }
-
     fun getActions(channelIds: IntArray?, recipientInstitutionId: Int): List<HoverAction> {
         return actionDao.getActions(channelIds, recipientInstitutionId, HoverAction.P2P)
     }

--- a/app/src/main/java/com/hover/stax/data/repository/AccountRepositoryImpl.kt
+++ b/app/src/main/java/com/hover/stax/data/repository/AccountRepositoryImpl.kt
@@ -1,40 +1,33 @@
 package com.hover.stax.data.repository
 
 import android.content.Context
-import com.hover.sdk.actions.HoverAction
 import com.hover.sdk.api.ActionApi
 import com.hover.sdk.sims.SimInfo
 import com.hover.stax.R
-import com.hover.stax.channels.Channel
 import com.hover.stax.data.local.accounts.AccountRepo
 import com.hover.stax.data.local.actions.ActionRepo
 import com.hover.stax.data.local.channels.ChannelRepo
 import com.hover.stax.domain.model.Account
-import com.hover.stax.domain.model.PLACEHOLDER
 import com.hover.stax.domain.repository.AccountRepository
 import com.hover.stax.notifications.PushNotificationTopicsInterface
 import com.hover.stax.utils.AnalyticsUtil
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import timber.log.Timber
 
 class AccountRepositoryImpl(val accountRepo: AccountRepo, private val channelRepo: ChannelRepo, val actionRepo: ActionRepo) :
     AccountRepository, PushNotificationTopicsInterface, KoinComponent {
 
     private val context: Context by inject()
 
-    override val fetchAccounts: Flow<List<Account>>
+    override val addedAccounts: Flow<List<Account>>
         get() = accountRepo.getAccounts()
 
     override suspend fun createAccount(sim: SimInfo): Account {
         var account = Account(generateSimBasedName(sim), generateSimBasedAlias(sim))
         channelRepo.getTelecom(sim.osReportedHni)?.let {
-            account = Account(account.name, account.alias, it, false, sim.subscriptionId)
+            account = Account(account.userAlias, it, false, sim.subscriptionId)
             accountRepo.insert(account)
         }
         logChoice(account)
@@ -53,8 +46,6 @@ class AccountRepositoryImpl(val accountRepo: AccountRepo, private val channelRep
     override suspend fun getAccountBySim(subscriptionId: Int): Account? {
         return accountRepo.getAccountBySim(subscriptionId)
     }
-
-    private fun getFetchAccountAction(channelId: Int): HoverAction? = actionRepo.getActions(channelId, HoverAction.FETCH_ACCOUNTS).firstOrNull()
 
     private fun logChoice(account: Account) {
         joinChannelGroup(account.channelId, context)

--- a/app/src/main/java/com/hover/stax/database/AppDatabase.kt
+++ b/app/src/main/java/com/hover/stax/database/AppDatabase.kt
@@ -33,14 +33,15 @@ import java.util.concurrent.Executors
     entities = [
         Channel::class, StaxTransaction::class, StaxContact::class, Request::class, Schedule::class, Account::class, Paybill::class, Merchant::class, StaxUser::class, Bonus::class
     ],
-    version = 46,
+    version = 47,
     autoMigrations = [
         AutoMigration(from = 36, to = 37),
         AutoMigration(from = 37, to = 38),
         AutoMigration(from = 38, to = 39),
         AutoMigration(from = 40, to = 41),
         AutoMigration(from = 41, to = 42),
-        AutoMigration(from = 43, to = 44)
+        AutoMigration(from = 43, to = 44),
+        AutoMigration(from = 46, to = 47)
     ]
 )
 
@@ -232,7 +233,7 @@ abstract class AppDatabase : RoomDatabase() {
 
         private val M44_45: Migration = Migration(44, 45) {}
 
-        private val M45_46 = Migration(45, 46) { database -> //accounts table changes
+        private val M45_46 = Migration(45, 46) { database ->
             database.execSQL(
                 "CREATE TABLE IF NOT EXISTS `channels_new` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `country_alpha2` TEXT NOT NULL, `root_code` TEXT, " +
                         "`currency` TEXT NOT NULL, `hni_list` TEXT NOT NULL, `logo_url` TEXT NOT NULL, `institution_id` INTEGER NOT NULL, `primary_color_hex` TEXT NOT NULL, `published` INTEGER NOT NULL DEFAULT 0," +
@@ -247,11 +248,16 @@ abstract class AppDatabase : RoomDatabase() {
             database.execSQL("ALTER TABLE channels_new RENAME TO channels")
         }
 
+        private val M47_48 = Migration(47, 48) { database ->
+            database.execSQL("DROP INDEX index_accounts_name")
+            database.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_accounts_name_sim_subscription_id ON accounts(name, sim_subscription_id)")
+        }
+
         fun getInstance(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, "stax.db")
                     .setJournalMode(JournalMode.WRITE_AHEAD_LOGGING)
-                    .addMigrations(M23_24, M24_25, M25_26, M26_27, M27_28, M28_29, M29_30, M30_31, M31_32, M32_33, M33_34, M34_35, M35_36, M39_40, M42_43, M44_45, M45_46)
+                    .addMigrations(M23_24, M24_25, M25_26, M26_27, M27_28, M28_29, M29_30, M30_31, M31_32, M32_33, M33_34, M34_35, M35_36, M39_40, M42_43, M44_45, M45_46, M47_48)
                     .build()
                 INSTANCE = instance
 

--- a/app/src/main/java/com/hover/stax/domain/model/Account.kt
+++ b/app/src/main/java/com/hover/stax/domain/model/Account.kt
@@ -8,19 +8,20 @@ import com.hover.stax.utils.DateUtils.now
 import timber.log.Timber
 import kotlin.random.Random
 
-const val PLACEHOLDER = " placeholder"
 const val ACCOUNT_NAME: String = "account_name"
 const val ACCOUNT_ID: String = "account_id"
 
 @Entity(
         tableName = "accounts",
         foreignKeys = [ForeignKey(entity = Channel::class, parentColumns = ["id"], childColumns = ["channelId"])],
-        indices = [Index(value = ["name"], unique = true)]
+        indices = [Index(value = ["name", "sim_subscription_id"], unique = true)]
 )
 data class Account(
-        val name: String,
+        @ColumnInfo(name = "name")
+        val institutionName: String,
 
-        var alias: String,
+        @ColumnInfo(name = "alias")
+        var userAlias: String,
 
         @ColumnInfo(name = "logo_url")
         val logoUrl: String,
@@ -59,17 +60,19 @@ data class Account(
 
     constructor(name: String) : this(name, name)
     constructor(name: String, alias: String) : this(
-        name = name, alias = alias, logoUrl = "", accountNo = "", institutionId = -1, institutionType = "", countryAlpha2 = "", channelId = -1, primaryColorHex = "#292E35", secondaryColorHex = "#1E232A"
+        institutionName = name, userAlias = alias, logoUrl = "", accountNo = "", institutionId = -1, institutionType = "", countryAlpha2 = "", channelId = -1, primaryColorHex = "#292E35", secondaryColorHex = "#1E232A"
     )
-    constructor(name: String, channel: Channel, isDefault: Boolean, simSubscriptionId: Int) : this(
-        name, name, channel, isDefault, simSubscriptionId
+    constructor(channel: Channel, isDefault: Boolean, simSubscriptionId: Int) : this(
+        channel.name, channel, isDefault, simSubscriptionId
     )
-    constructor(name: String, alias: String, channel: Channel, isDefault: Boolean, simSubscriptionId: Int) : this(
-        name, alias, channel.logoUrl, "", channel.institutionId, channel.institutionType, channel.countryAlpha2, channel.id, channel.primaryColorHex, channel.secondaryColorHex, isDefault, simSubscriptionId
+    constructor(alias: String, channel: Channel, isDefault: Boolean, simSubscriptionId: Int) : this(
+        channel.name, alias, channel.logoUrl, "", channel.institutionId, channel.institutionType, channel.countryAlpha2, channel.id, channel.primaryColorHex, channel.secondaryColorHex, isDefault, simSubscriptionId
     )
 
     @PrimaryKey(autoGenerate = true)
     var id: Int = 0
+
+    var institutionAccountName: String? = null
 
     var latestBalance: String? = null
 
@@ -88,8 +91,12 @@ data class Account(
         }
     }
 
+    fun getAccountNameExtra(): String {
+        return institutionAccountName ?: "1"
+    }
+
     override fun toString() = buildString {
-        append(alias)
+        append(userAlias)
 
         if (!accountNo.isNullOrEmpty()) {
             append(" - ")
@@ -97,10 +104,10 @@ data class Account(
         }
     }
 
-    //    Name is unique
     override fun equals(other: Any?): Boolean {
         if (other !is Account) return false
-        return id == other.id || other.name == other.name
+        return id == other.id ||
+                (institutionName == other.institutionName && simSubscriptionId == other.simSubscriptionId && institutionAccountName == other.institutionAccountName)
     }
 
     override fun compareTo(other: Account): Int = toString().compareTo(other.toString())

--- a/app/src/main/java/com/hover/stax/domain/repository/AccountRepository.kt
+++ b/app/src/main/java/com/hover/stax/domain/repository/AccountRepository.kt
@@ -6,7 +6,7 @@ import com.hover.stax.channels.Channel
 import kotlinx.coroutines.flow.Flow
 
 interface AccountRepository {
-    val fetchAccounts: Flow<List<Account>>
+    val addedAccounts: Flow<List<Account>>
 
     suspend fun createAccount(sim: SimInfo): Account
 

--- a/app/src/main/java/com/hover/stax/hover/AbstractHoverCallerActivity.kt
+++ b/app/src/main/java/com/hover/stax/hover/AbstractHoverCallerActivity.kt
@@ -49,15 +49,6 @@ abstract class AbstractHoverCallerActivity : AppCompatActivity(), PushNotificati
         runSession(account, action, null, account.id)
     }
 
-    private fun getAccountNameExtra(account: Account, action: HoverAction): HashMap<String, String>? {
-        if (action.requiredParams.contains(ACCOUNT_NAME)) {
-            val extras = HashMap<String, String>()
-            extras[ACCOUNT_NAME] =
-            return extras
-        }
-        return null
-    }
-
     fun runSession(account: Account, action: HoverAction, extras: HashMap<String, String>?, requestCode: Int) {
         val hsb = HoverSession.Builder(action, account, this@AbstractHoverCallerActivity, requestCode)
         if (!extras.isNullOrEmpty()) hsb.extras(extras)

--- a/app/src/main/java/com/hover/stax/hover/AbstractHoverCallerActivity.kt
+++ b/app/src/main/java/com/hover/stax/hover/AbstractHoverCallerActivity.kt
@@ -8,6 +8,7 @@ import com.hover.sdk.api.HoverParameters
 import com.hover.sdk.transactions.TransactionContract
 import com.hover.stax.R
 import com.hover.stax.domain.model.Account
+import com.hover.stax.domain.model.ACCOUNT_NAME
 import com.hover.stax.presentation.home.BalancesViewModel
 import com.hover.stax.home.NavHelper
 import com.hover.stax.notifications.PushNotificationTopicsInterface
@@ -27,7 +28,6 @@ const val SCHEDULED = "SCHEDULED"
 const val TRANSFER_REQUEST = 203
 const val SCHEDULE_REQUEST = 204
 const val REQUEST_REQUEST = 301
-const val FETCH_ACCOUNT_REQUEST = 205
 const val BOUNTY_REQUEST = 207
 const val FEE_REQUEST = 208
 
@@ -46,7 +46,16 @@ abstract class AbstractHoverCallerActivity : AppCompatActivity(), PushNotificati
     }
 
     fun runSession(account: Account, action: HoverAction) {
-        runSession(account, action, null, account.id) // Constants.REQUEST_REQUEST
+        runSession(account, action, null, account.id)
+    }
+
+    private fun getAccountNameExtra(account: Account, action: HoverAction): HashMap<String, String>? {
+        if (action.requiredParams.contains(ACCOUNT_NAME)) {
+            val extras = HashMap<String, String>()
+            extras[ACCOUNT_NAME] =
+            return extras
+        }
+        return null
     }
 
     fun runSession(account: Account, action: HoverAction, extras: HashMap<String, String>?, requestCode: Int) {
@@ -64,11 +73,6 @@ abstract class AbstractHoverCallerActivity : AppCompatActivity(), PushNotificati
         }
         AnalyticsUtil.logAnalyticsEvent(event, data, this)
         Timber.e(event)
-    }
-
-    private fun getRequestCode(transactionType: String): Int {
-        return if (transactionType == HoverAction.FETCH_ACCOUNTS) FETCH_ACCOUNT_REQUEST
-        else TRANSFER_REQUEST
     }
 
     fun makeRegularCall(a: HoverAction, analytics: Int) {

--- a/app/src/main/java/com/hover/stax/hover/HoverSession.kt
+++ b/app/src/main/java/com/hover/stax/hover/HoverSession.kt
@@ -32,7 +32,7 @@ class HoverSession private constructor(b: Builder) {
     private fun getBasicBuilder(b: Builder): HoverParameters.Builder = HoverParameters.Builder(b.activity)
         .apply {
             setEnvironment(if (Utils.getBoolean(TEST_MODE, b.activity)) HoverParameters.TEST_ENV else HoverParameters.PROD_ENV)
-            extra(ACCOUNT_NAME, account.name)
+            extra(ACCOUNT_NAME, account.getAccountNameExtra())
             private_extra(ACCOUNT_ID, account.id.toString())
             request(b.action.public_id)
             setHeader(getMessage(b.action, b.activity))
@@ -64,7 +64,6 @@ class HoverSession private constructor(b: Builder) {
         return when (a.transaction_type) {
             HoverAction.BALANCE -> c.getString(R.string.balance_msg, a.from_institution_name)
             HoverAction.AIRTIME -> c.getString(R.string.airtime_msg)
-            HoverAction.FETCH_ACCOUNTS -> c.getString(R.string.fetch_accounts)
             else -> c.getString(R.string.transfer_msg)
         }
     }

--- a/app/src/main/java/com/hover/stax/hover/TransactionReceiver.kt
+++ b/app/src/main/java/com/hover/stax/hover/TransactionReceiver.kt
@@ -178,24 +178,21 @@ class TransactionReceiver : BroadcastReceiver(), KoinComponent {
 
         while (matcher.find()) {
             try {
-                if (IntRange(1, 8).contains(Integer.valueOf(matcher.group(1)!!))) { // Navigation options like back are usually 0 or 00 or 9 and above
+                val accounts = accountRepo.getAccountsByChannel(channel!!.id)
+                if (accounts.any { it.institutionAccountName == matcher.group(2)!! }) { break }
 
-                    val accounts = accountRepo.getAccountsByChannel(channel!!.id)
-                    if (accounts.any { it.institutionAccountName == matcher.group(2)!! }) { break }
-
-                    val a = if (account != null && account!!.institutionAccountName == null) {
-                        account!!
-                    } else if (accounts.any { it.institutionAccountName == null }) {
-                        accounts.first { it.institutionAccountName == null }
-                    } else {
-                        Account(matcher.group(2)!!, channel!!, false, account?.simSubscriptionId ?: -1)
-                    }
-
-                    a.institutionAccountName = matcher.group(2)!!
-                    if (a.institutionName == a.userAlias) a.userAlias = matcher.group(2)!!
-
-                    accountRepo.saveAccount(a)
+                val a = if (account != null && account!!.institutionAccountName == null) {
+                    account!!
+                } else if (accounts.any { it.institutionAccountName == null }) {
+                    accounts.first { it.institutionAccountName == null }
+                } else {
+                    Account(matcher.group(2)!!, channel!!, false, account?.simSubscriptionId ?: -1)
                 }
+
+                a.institutionAccountName = matcher.group(2)!!
+                if (a.institutionName == a.userAlias) a.userAlias = matcher.group(2)!!
+
+                accountRepo.saveAccount(a)
             } catch (e: Exception) { AnalyticsUtil.logErrorAndReportToFirebase(TransactionReceiver::class.java.simpleName, "Failed to parse account list from USSD", e)}
         }
     }

--- a/app/src/main/java/com/hover/stax/merchants/Merchant.kt
+++ b/app/src/main/java/com/hover/stax/merchants/Merchant.kt
@@ -44,9 +44,10 @@ data class Merchant(
 			append(")")
 	}
 
+//	FIXME: Is this actually used?
 	override fun equals(other: Any?): Boolean {
-		if (other !is Account) return false
-		return id == other.id || other.name == other.name
+		if (other !is Merchant) return false
+		return id == other.id || (channelId == other.channelId && tillNo == tillNo)
 	}
 
 	override fun compareTo(other: Merchant): Int = tillNo.compareTo(other.tillNo)

--- a/app/src/main/java/com/hover/stax/paybill/PayBill.kt
+++ b/app/src/main/java/com/hover/stax/paybill/PayBill.kt
@@ -61,9 +61,10 @@ data class Paybill(
         append(")")
     }
 
+    // FIXME: is this actually used?
     override fun equals(other: Any?): Boolean {
-        if (other !is Account) return false
-        return id == other.id || other.name == other.name
+        if (other !is Paybill) return false
+        return id == other.id || (channelId == other.channelId && businessNo == other.businessNo) // FIXME: should be institution id not channel id
     }
 
     override fun compareTo(other: Paybill): Int = toString().compareTo(other.toString())

--- a/app/src/main/java/com/hover/stax/presentation/home/BalancesViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/BalancesViewModel.kt
@@ -13,7 +13,6 @@ import com.hover.stax.data.local.accounts.AccountRepo
 import com.hover.stax.data.local.actions.ActionRepo
 
 import com.hover.stax.domain.model.Account
-import com.hover.stax.domain.model.PLACEHOLDER
 import com.hover.stax.utils.AnalyticsUtil
 
 import kotlinx.coroutines.Dispatchers
@@ -58,10 +57,10 @@ class BalancesViewModel(application: Application, val actionRepo: ActionRepo, va
     }
 
     private fun startBalanceActionFor(account: Account?) = viewModelScope.launch(Dispatchers.IO) {
-        if(account == null) return@launch
+        if (account == null) return@launch
 
         val channelId = account.channelId
-        val action = actionRepo.getActions(channelId, if (account.name.contains(PLACEHOLDER)) HoverAction.FETCH_ACCOUNTS else HoverAction.BALANCE).firstOrNull()
+        val action = actionRepo.getFirstAction(channelId, HoverAction.BALANCE)
         action?.let { _balanceAction.emit(action) } ?: run { _actionRunError.send((getApplication() as Context).getString(R.string.error_running_action)) }
     }
 

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeViewModel.kt
@@ -50,7 +50,7 @@ class HomeViewModel(
     }
 
     private fun getAccounts() = viewModelScope.launch {
-        accountsRepo.fetchAccounts.collect { accounts ->
+        accountsRepo.addedAccounts.collect { accounts ->
             _homeState.update { it.copy(accounts = accounts) }
             _accounts.postValue(accounts)
         }

--- a/app/src/main/java/com/hover/stax/presentation/home/components/BalanceItem.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/components/BalanceItem.kt
@@ -54,7 +54,7 @@ fun BalanceItem(staxAccount: Account, balanceTapListener: BalanceTapListener?, c
             )
 
             Text(
-                text = staxAccount.alias,
+                text = staxAccount.userAlias,
                 style = MaterialTheme.typography.body2,
                 modifier = Modifier
                     .weight(1f)

--- a/app/src/main/java/com/hover/stax/presentation/sims/components/SimItem.kt
+++ b/app/src/main/java/com/hover/stax/presentation/sims/components/SimItem.kt
@@ -108,7 +108,7 @@ private fun emailStax(simWithAccount: SimWithAccount, context: Context) {
 	val emailBody = context.getString(
 		R.string.sim_card_support_request_emailBody,
 		simWithAccount.sim.osReportedHni ?: "Null",
-		simWithAccount.sim.operatorName ?: simWithAccount.account.alias,
+		simWithAccount.sim.operatorName ?: simWithAccount.account.userAlias,
 		simWithAccount.sim.networkOperator ?: "Null",
 		simWithAccount.sim.countryIso ?: "Null"
 	)
@@ -128,7 +128,7 @@ private fun SimItemTopRow(
 		AsyncImage(
 			model = ImageRequest.Builder(LocalContext.current).data(simWithAccount.account.logoUrl).crossfade(true)
 				.diskCachePolicy(CachePolicy.ENABLED).build(),
-			contentDescription = simWithAccount.account.alias + " logo",
+			contentDescription = simWithAccount.account.userAlias + " logo",
 			placeholder = painterResource(id = R.drawable.img_placeholder),
 			error = painterResource(id = R.drawable.img_placeholder),
 			modifier = Modifier
@@ -143,7 +143,7 @@ private fun SimItemTopRow(
 				.padding(horizontal = 13.dp)
 				.weight(1f)
 		) {
-			Text(text = simWithAccount.account.alias, style = MaterialTheme.typography.body1)
+			Text(text = simWithAccount.account.userAlias, style = MaterialTheme.typography.body1)
 			Text(
 				text = getSimSlot(simWithAccount.sim, LocalContext.current),
 				color = TextGrey,

--- a/app/src/main/java/com/hover/stax/presentation/welcome/WelcomeFragment.kt
+++ b/app/src/main/java/com/hover/stax/presentation/welcome/WelcomeFragment.kt
@@ -27,7 +27,7 @@ class WelcomeFragment : Fragment() {
             id = R.id.welcomeFragment
             val buttonText = getString(R.string.explore_btn_text)
             setContent {
-                WelcomeScreen(buttonText, { onClickGetStarted() }, { onClickLogin() }, showExploreButton = false)
+                WelcomeScreen(buttonText, { onClickGetStarted() }, { onClickLogin() }, showExploreButton = true)
             }
         }
 

--- a/app/src/main/java/com/hover/stax/requests/NewRequestFragment.kt
+++ b/app/src/main/java/com/hover/stax/requests/NewRequestFragment.kt
@@ -226,12 +226,12 @@ class NewRequestFragment : AbstractFormFragment(), PushNotificationTopicsInterfa
         val recipientError = requestViewModel.requesteeErrors()
         requesteeInput.setState(recipientError, if (recipientError == null) AbstractStatefulInput.SUCCESS else AbstractStatefulInput.ERROR)
 
-        requestViewModel.activeAccount.value?.let {
-            if (!requestViewModel.isValidAccount()) {
-                payWithDropdown.setState(getString(R.string.incomplete_account_setup_header), AbstractStatefulInput.ERROR)
-                return false
-            }
-        }
+//        requestViewModel.activeAccount.value?.let {
+//            if (!requestViewModel.isValidAccount()) {
+//                payWithDropdown.setState(getString(R.string.incomplete_account_setup_header), AbstractStatefulInput.ERROR)
+//                return false
+//            }
+//        }
 
         return accountError == null && requesterAcctNoError == null && recipientError == null
     }

--- a/app/src/main/java/com/hover/stax/requests/NewRequestFragment.kt
+++ b/app/src/main/java/com/hover/stax/requests/NewRequestFragment.kt
@@ -226,13 +226,6 @@ class NewRequestFragment : AbstractFormFragment(), PushNotificationTopicsInterfa
         val recipientError = requestViewModel.requesteeErrors()
         requesteeInput.setState(recipientError, if (recipientError == null) AbstractStatefulInput.SUCCESS else AbstractStatefulInput.ERROR)
 
-//        requestViewModel.activeAccount.value?.let {
-//            if (!requestViewModel.isValidAccount()) {
-//                payWithDropdown.setState(getString(R.string.incomplete_account_setup_header), AbstractStatefulInput.ERROR)
-//                return false
-//            }
-//        }
-
         return accountError == null && requesterAcctNoError == null && recipientError == null
     }
 

--- a/app/src/main/java/com/hover/stax/requests/NewRequestViewModel.kt
+++ b/app/src/main/java/com/hover/stax/requests/NewRequestViewModel.kt
@@ -9,7 +9,6 @@ import com.hover.stax.domain.model.Account
 import com.hover.stax.data.local.accounts.AccountRepo
 import com.hover.stax.contacts.ContactRepo
 import com.hover.stax.contacts.StaxContact
-import com.hover.stax.domain.model.PLACEHOLDER
 import com.hover.stax.schedules.ScheduleRepo
 import com.hover.stax.schedules.Schedule
 import com.hover.stax.transfers.AbstractFormViewModel
@@ -68,8 +67,6 @@ class NewRequestViewModel(application: Application, val repo: RequestRepo, val a
     }
 
     fun accountError(): String? = if (activeAccount.value != null) null else getString(R.string.accounts_error_noselect)
-
-    fun isValidAccount(): Boolean = !activeAccount.value!!.name.contains(PLACEHOLDER)
 
     fun requesterAcctNoError(): String? = if (!requesterNumber.value.isNullOrEmpty()) null else getString(R.string.requester_number_fielderror)
 

--- a/app/src/main/java/com/hover/stax/requests/RequestDetailFragment.kt
+++ b/app/src/main/java/com/hover/stax/requests/RequestDetailFragment.kt
@@ -56,7 +56,7 @@ class RequestDetailFragment: Fragment(), RequestSenderInterface  {
 
         viewModel.account.observe(viewLifecycleOwner) {
             binding.summaryCard.requesterAccountRow.visibility = if (it != null) View.VISIBLE else View.GONE
-            it?.let { (view.findViewById(R.id.requesterValue) as Stax2LineItem).setTitle(it.name)  }
+            it?.let { (view.findViewById(R.id.requesterValue) as Stax2LineItem).setTitle(it.userAlias)  }
         }
 
         viewModel.request.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/hover/stax/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/hover/stax/settings/SettingsFragment.kt
@@ -200,7 +200,7 @@ class SettingsFragment : Fragment() {
             a
         }
 
-        spinner.setText(defaultAccount?.alias, false)
+        spinner.setText(defaultAccount?.userAlias, false)
         spinner.onItemClickListener = OnItemClickListener { _, _, pos: Int, _ -> if (pos != -1) accountsViewModel.setDefaultAccount(accounts[pos]) }
     }
 

--- a/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsFragment.kt
+++ b/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsFragment.kt
@@ -212,8 +212,8 @@ class TransactionDetailsFragment : Fragment() {
     }
 
     private fun updateAccount(account: Account) {
-        binding.details.paidWithValue.text = account.name
-        binding.details.feeLabel.text = getString(R.string.transaction_fee, account.name)
+        binding.details.paidWithValue.text = account.userAlias
+        binding.details.feeLabel.text = getString(R.string.transaction_fee, account.institutionName)
     }
 
     private fun updateMessages(ussdCallResponses: List<UssdCallResponse>?) {

--- a/app/src/main/java/com/hover/stax/transactions/StaxTransaction.kt
+++ b/app/src/main/java/com/hover/stax/transactions/StaxTransaction.kt
@@ -139,7 +139,6 @@ data class StaxTransaction(
 		val amountStr = Utils.formatAmount(amount)
 		return when(transaction_type) {
 			HoverAction.RECEIVE -> c.getString(R.string.descrip_transfer_received, contact!!.shortName())
-			HoverAction.FETCH_ACCOUNTS -> c.getString(R.string.descrip_fetch_accounts, action.from_institution_name)
 			HoverAction.BALANCE -> c.getString(R.string.descrip_balance, action.from_institution_name)
 			HoverAction.AIRTIME -> c.getString(R.string.descrip_airtime_sent, amountStr,
 			if (contact == null) c.getString(R.string.self_choice) else contact.shortName())

--- a/app/src/main/java/com/hover/stax/transfers/AbstractFormFragment.kt
+++ b/app/src/main/java/com/hover/stax/transfers/AbstractFormFragment.kt
@@ -116,7 +116,7 @@ abstract class AbstractFormFragment : Fragment() {
     private fun askToCheckBalance(account: Account) {
         val dialog = StaxDialog(layoutInflater)
             .setDialogTitle(R.string.finish_adding_title)
-            .setDialogMessage(getString(R.string.finish_adding_desc, account.alias))
+            .setDialogMessage(getString(R.string.finish_adding_desc, account.userAlias))
             .setNegButton(R.string.btn_cancel, null)
             .setPosButton(R.string.connect_cta) { balancesViewModel.requestBalance(account) }
         dialog.showIt()


### PR DESCRIPTION
Remove use of fetch accounts actions, remove use of placeholder as name. Update account db/model fields to make them clearer, fix to the way creating multiple accounts for a given bank or channel works.

Now when an account is first added the check balance action should always be run. If an account name choice is encountered then 1 will always be chosen. Once the transaction has finished Stax will parse any `userAccountList` in the output variables and update/create accounts for each item in the list.

I can't actually test this as I don't have access to any bank USSD channels. Note that it requires latest SDK update.