### PR TITLE
Show Google Login Failure Error

### DIFF
--- a/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
+++ b/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
@@ -29,154 +29,158 @@ import timber.log.Timber
 const val FORCED_VERSION = "force_update_app_version"
 
 abstract class AbstractGoogleAuthActivity : AbstractHoverCallerActivity(),
-	StaxGoogleLoginInterface {
+    StaxGoogleLoginInterface {
 
-	private val loginViewModel: LoginViewModel by viewModel()
-	private lateinit var staxGoogleLoginInterface: StaxGoogleLoginInterface
+    private val loginViewModel: LoginViewModel by viewModel()
+    private lateinit var staxGoogleLoginInterface: StaxGoogleLoginInterface
 
-	private lateinit var updateManager: AppUpdateManager
-	private var installListener: InstallStateUpdatedListener? = null
+    private lateinit var updateManager: AppUpdateManager
+    private var installListener: InstallStateUpdatedListener? = null
 
-	override fun onCreate(savedInstanceState: Bundle?) {
-		super.onCreate(savedInstanceState)
-		initGoogleAuth()
-		setLoginObserver()
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initGoogleAuth()
+        setLoginObserver()
 
-		updateManager = AppUpdateManagerFactory.create(this)
+        updateManager = AppUpdateManagerFactory.create(this)
 
-		if (!BuildConfig.DEBUG) checkForUpdates()
-	}
+        if (!BuildConfig.DEBUG) checkForUpdates()
+    }
 
-	//checks that the update has not stalled
-	override fun onResume() {
-		super.onResume()
-		if (!BuildConfig.DEBUG) updateManager.appUpdateInfo.addOnSuccessListener { updateInfo -> //if the update is downloaded but not installed, notify user to complete the update
-			if (updateInfo.installStatus() == DOWNLOADED) showSnackbarForCompleteUpdate()
+    //checks that the update has not stalled
+    override fun onResume() {
+        super.onResume()
+        if (!BuildConfig.DEBUG) updateManager.appUpdateInfo.addOnSuccessListener { updateInfo -> //if the update is downloaded but not installed, notify user to complete the update
+            if (updateInfo.installStatus() == DOWNLOADED) showSnackbarForCompleteUpdate()
 
-			//if an in-app update is already running, resume the update
-			if (updateInfo.updateAvailability() == DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
-				updateManager.startUpdateFlowForResult(
-					updateInfo, IMMEDIATE, this, UPDATE_REQUEST_CODE
-				)
-			}
-		}
-	}
+            //if an in-app update is already running, resume the update
+            if (updateInfo.updateAvailability() == DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
+                updateManager.startUpdateFlowForResult(
+                    updateInfo, IMMEDIATE, this, UPDATE_REQUEST_CODE
+                )
+            }
+        }
+    }
 
-	fun setGoogleLoginInterface(staxGoogleLoginInterface: StaxGoogleLoginInterface) {
-		this.staxGoogleLoginInterface = staxGoogleLoginInterface
-	}
+    fun setGoogleLoginInterface(staxGoogleLoginInterface: StaxGoogleLoginInterface) {
+        this.staxGoogleLoginInterface = staxGoogleLoginInterface
+    }
 
-	private fun initGoogleAuth() {
-		val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-			.requestIdToken(getString(R.string.google_server_client_id)).requestEmail().build()
-		loginViewModel.signInClient = GoogleSignIn.getClient(this, gso)
-	}
+    private fun initGoogleAuth() {
+        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestIdToken(getString(R.string.google_server_client_id)).requestEmail().build()
+        loginViewModel.signInClient = GoogleSignIn.getClient(this, gso)
+    }
 
-	private fun setLoginObserver() = with(loginViewModel) {
-		error.observe(this@AbstractGoogleAuthActivity) {
-			it?.let { staxGoogleLoginInterface.googleLoginFailed() }
-		}
+    private fun setLoginObserver() = with(loginViewModel) {
+        error.observe(this@AbstractGoogleAuthActivity) {
+            it?.let { staxGoogleLoginInterface.googleLoginFailed() }
+        }
 
-		googleUser.observe(this@AbstractGoogleAuthActivity) {
-			it?.let { staxGoogleLoginInterface.googleLoginSuccessful() }
-		}
-	}
+        googleUser.observe(this@AbstractGoogleAuthActivity) {
+            it?.let { staxGoogleLoginInterface.googleLoginSuccessful() }
+        }
+    }
 
-	fun signIn() = loginForResult.launch(loginViewModel.signInClient.signInIntent)
+    fun signIn() = loginForResult.launch(loginViewModel.signInClient.signInIntent)
 
-	private val loginForResult =
-		registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-			if (result.resultCode == RESULT_OK) loginViewModel.signIntoGoogle(result.data)
-		}
+    private val loginForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == RESULT_OK) {
+                loginViewModel.signIntoGoogle(result.data)
+            } else {
+                staxGoogleLoginInterface.googleLoginFailed()
+            }
+        }
 
-	private fun checkForUpdates() {
-		val updateInfoTask = updateManager.appUpdateInfo
+    private fun checkForUpdates() {
+        val updateInfoTask = updateManager.appUpdateInfo
 
-		updateInfoTask.addOnSuccessListener { updateInfo ->
-			val updateType = getUpdateType(updateInfo)
-			if (updateInfo.updateAvailability() == UPDATE_AVAILABLE && updateInfo.isUpdateTypeAllowed(
-					updateType
-				)
-			) {
-				logAppUpdate(STARTED)
-				requestUpdate(updateInfo, updateType)
-			} else {
-				Timber.i("No new update available")
-			}
-		}
-	}
+        updateInfoTask.addOnSuccessListener { updateInfo ->
+            val updateType = getUpdateType(updateInfo)
+            if (updateInfo.updateAvailability() == UPDATE_AVAILABLE && updateInfo.isUpdateTypeAllowed(
+                    updateType
+                )
+            ) {
+                logAppUpdate(STARTED)
+                requestUpdate(updateInfo, updateType)
+            } else {
+                Timber.i("No new update available")
+            }
+        }
+    }
 
-	private fun logAppUpdate(status: String) {
-		AnalyticsUtil.logAnalyticsEvent(getString(R.string.force_update_status, status), this)
-	}
+    private fun logAppUpdate(status: String) {
+        AnalyticsUtil.logAnalyticsEvent(getString(R.string.force_update_status, status), this)
+    }
 
-	private fun getUpdateType(updateInfo: AppUpdateInfo): Int {
-		val isGracePeriod =
-			(updateInfo.clientVersionStalenessDays() ?: -1) <= DAYS_FOR_FLEXIBLE_UPDATE
-		val mustForceUpdate = BuildConfig.VERSION_CODE < Utils.getInt(FORCED_VERSION, this)
-		return if (mustForceUpdate || !isGracePeriod) IMMEDIATE
-		else FLEXIBLE
-	}
+    private fun getUpdateType(updateInfo: AppUpdateInfo): Int {
+        val isGracePeriod =
+            (updateInfo.clientVersionStalenessDays() ?: -1) <= DAYS_FOR_FLEXIBLE_UPDATE
+        val mustForceUpdate = BuildConfig.VERSION_CODE < Utils.getInt(FORCED_VERSION, this)
+        return if (mustForceUpdate || !isGracePeriod) IMMEDIATE
+        else FLEXIBLE
+    }
 
-	private fun requestUpdate(updateInfo: AppUpdateInfo, updateType: Int) {
-		if (updateType == FLEXIBLE) {
-			installListener = InstallStateUpdatedListener {
-				if (it.installStatus() == DOWNLOADED) showSnackbarForCompleteUpdate()
-			}
-			updateManager.registerListener(installListener!!)
-		}
+    private fun requestUpdate(updateInfo: AppUpdateInfo, updateType: Int) {
+        if (updateType == FLEXIBLE) {
+            installListener = InstallStateUpdatedListener {
+                if (it.installStatus() == DOWNLOADED) showSnackbarForCompleteUpdate()
+            }
+            updateManager.registerListener(installListener!!)
+        }
 
-		updateManager.startUpdateFlowForResult(updateInfo, updateType, this, UPDATE_REQUEST_CODE)
-	}
+        updateManager.startUpdateFlowForResult(updateInfo, updateType, this, UPDATE_REQUEST_CODE)
+    }
 
-	private fun showSnackbarForCompleteUpdate() {
-		Snackbar.make(
-			findViewById(R.id.home_root),
-			getString(R.string.update_downloaded),
-			Snackbar.LENGTH_INDEFINITE
-		).apply {
-			setAction(getString(R.string.restart)) {
-				updateManager.completeUpdate(); installListener?.let {
-				updateManager.unregisterListener(
-					it
-				)
-			}
-			}
-			setActionTextColor(
-				ContextCompat.getColor(
-					this@AbstractGoogleAuthActivity, R.color.stax_state_blue
-				)
-			)
-			show()
-		}
-	}
+    private fun showSnackbarForCompleteUpdate() {
+        Snackbar.make(
+            findViewById(R.id.home_root),
+            getString(R.string.update_downloaded),
+            Snackbar.LENGTH_INDEFINITE
+        ).apply {
+            setAction(getString(R.string.restart)) {
+                updateManager.completeUpdate(); installListener?.let {
+                updateManager.unregisterListener(
+                    it
+                )
+            }
+            }
+            setActionTextColor(
+                ContextCompat.getColor(
+                    this@AbstractGoogleAuthActivity, R.color.stax_state_blue
+                )
+            )
+            show()
+        }
+    }
 
-	override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-		super.onActivityResult(requestCode, resultCode, data)
-		when (requestCode) { //
-			UPDATE_REQUEST_CODE -> if (resultCode == RESULT_OK) {
-				logAppUpdate(COMPLETED)
-			} else {
-				Timber.e("Update flow failed. Result code : $resultCode")
-				logAppUpdate(FAILED)
-				checkForUpdates()
-			}
-		}
-	}
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        when (requestCode) { //
+            UPDATE_REQUEST_CODE -> if (resultCode == RESULT_OK) {
+                logAppUpdate(COMPLETED)
+            } else {
+                Timber.e("Update flow failed. Result code : $resultCode")
+                logAppUpdate(FAILED)
+                checkForUpdates()
+            }
+        }
+    }
 
-	override fun googleLoginSuccessful() {
-		if (loginViewModel.staxUser.value?.isMapper == true) BountyApplicationFragmentDirections.actionBountyApplicationFragmentToBountyListFragment()
-	}
+    override fun googleLoginSuccessful() {
+        if (loginViewModel.staxUser.value?.isMapper == true) BountyApplicationFragmentDirections.actionBountyApplicationFragmentToBountyListFragment()
+    }
 
-	override fun googleLoginFailed() {
-		UIHelper.flashAndReportMessage(this, R.string.login_google_err)
-	}
+    override fun googleLoginFailed() {
+        UIHelper.flashAndReportMessage(this, R.string.login_google_err)
+    }
 
-	companion object {
-		const val DAYS_FOR_FLEXIBLE_UPDATE = 3
-		const val UPDATE_REQUEST_CODE = 90
-		const val STARTED = "STARTED"
-		const val COMPLETED = "COMPLETED"
-		const val FAILED = "FAILED"
-	}
+    companion object {
+        const val DAYS_FOR_FLEXIBLE_UPDATE = 3
+        const val UPDATE_REQUEST_CODE = 90
+        const val STARTED = "STARTED"
+        const val COMPLETED = "COMPLETED"
+        const val FAILED = "FAILED"
+    }
 }

--- a/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
+++ b/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
@@ -29,7 +29,7 @@ import timber.log.Timber
 const val FORCED_VERSION = "force_update_app_version"
 
 abstract class AbstractGoogleAuthActivity : AbstractHoverCallerActivity(),
-    StaxGoogleLoginInterface {
+        StaxGoogleLoginInterface {
 
     private val loginViewModel: LoginViewModel by viewModel()
     private lateinit var staxGoogleLoginInterface: StaxGoogleLoginInterface
@@ -56,7 +56,7 @@ abstract class AbstractGoogleAuthActivity : AbstractHoverCallerActivity(),
             //if an in-app update is already running, resume the update
             if (updateInfo.updateAvailability() == DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
                 updateManager.startUpdateFlowForResult(
-                    updateInfo, IMMEDIATE, this, UPDATE_REQUEST_CODE
+                        updateInfo, IMMEDIATE, this, UPDATE_REQUEST_CODE
                 )
             }
         }
@@ -68,7 +68,7 @@ abstract class AbstractGoogleAuthActivity : AbstractHoverCallerActivity(),
 
     private fun initGoogleAuth() {
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestIdToken(getString(R.string.google_server_client_id)).requestEmail().build()
+                .requestIdToken(getString(R.string.google_server_client_id)).requestEmail().build()
         loginViewModel.signInClient = GoogleSignIn.getClient(this, gso)
     }
 
@@ -85,13 +85,13 @@ abstract class AbstractGoogleAuthActivity : AbstractHoverCallerActivity(),
     fun signIn() = loginForResult.launch(loginViewModel.signInClient.signInIntent)
 
     private val loginForResult =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            if (result.resultCode == RESULT_OK) {
-                loginViewModel.signIntoGoogle(result.data)
-            } else {
-                staxGoogleLoginInterface.googleLoginFailed()
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == RESULT_OK) {
+                    loginViewModel.signIntoGoogle(result.data)
+                } else {
+                    staxGoogleLoginInterface.googleLoginFailed()
+                }
             }
-        }
 
     private fun checkForUpdates() {
         val updateInfoTask = updateManager.appUpdateInfo
@@ -99,8 +99,8 @@ abstract class AbstractGoogleAuthActivity : AbstractHoverCallerActivity(),
         updateInfoTask.addOnSuccessListener { updateInfo ->
             val updateType = getUpdateType(updateInfo)
             if (updateInfo.updateAvailability() == UPDATE_AVAILABLE && updateInfo.isUpdateTypeAllowed(
-                    updateType
-                )
+                            updateType
+                    )
             ) {
                 logAppUpdate(STARTED)
                 requestUpdate(updateInfo, updateType)
@@ -116,7 +116,7 @@ abstract class AbstractGoogleAuthActivity : AbstractHoverCallerActivity(),
 
     private fun getUpdateType(updateInfo: AppUpdateInfo): Int {
         val isGracePeriod =
-            (updateInfo.clientVersionStalenessDays() ?: -1) <= DAYS_FOR_FLEXIBLE_UPDATE
+                (updateInfo.clientVersionStalenessDays() ?: -1) <= DAYS_FOR_FLEXIBLE_UPDATE
         val mustForceUpdate = BuildConfig.VERSION_CODE < Utils.getInt(FORCED_VERSION, this)
         return if (mustForceUpdate || !isGracePeriod) IMMEDIATE
         else FLEXIBLE
@@ -135,21 +135,21 @@ abstract class AbstractGoogleAuthActivity : AbstractHoverCallerActivity(),
 
     private fun showSnackbarForCompleteUpdate() {
         Snackbar.make(
-            findViewById(R.id.home_root),
-            getString(R.string.update_downloaded),
-            Snackbar.LENGTH_INDEFINITE
+                findViewById(R.id.home_root),
+                getString(R.string.update_downloaded),
+                Snackbar.LENGTH_INDEFINITE
         ).apply {
             setAction(getString(R.string.restart)) {
                 updateManager.completeUpdate(); installListener?.let {
                 updateManager.unregisterListener(
-                    it
+                        it
                 )
             }
             }
             setActionTextColor(
-                ContextCompat.getColor(
-                    this@AbstractGoogleAuthActivity, R.color.stax_state_blue
-                )
+                    ContextCompat.getColor(
+                            this@AbstractGoogleAuthActivity, R.color.stax_state_blue
+                    )
             )
             show()
         }


### PR DESCRIPTION
When the `StartActivityForResult` returns a result which is not `RESULT_OK`, the app doesn't do anything. This PR allows the app to show a failure message

Easiest way to test this change is to delete your SHA-1 from Firebase, then build app and see if the error appears