### PR TITLE
fix for formatting retry amount. Removed the trailing .## to adds .00

### DIFF
--- a/app/src/main/java/com/hover/stax/utils/Utils.kt
+++ b/app/src/main/java/com/hover/stax/utils/Utils.kt
@@ -148,8 +148,6 @@ object Utils {
     fun formatAmountForUSSD(number: Double?): String {
         return try {
             val formatter = DecimalFormat("##0")
-            formatter.maximumFractionDigits = 2
-            formatter.minimumFractionDigits = 0
             formatter.format(number)
         } catch (e: Exception) {
             number.toString()

--- a/app/src/main/java/com/hover/stax/utils/Utils.kt
+++ b/app/src/main/java/com/hover/stax/utils/Utils.kt
@@ -147,7 +147,7 @@ object Utils {
     @JvmStatic
     fun formatAmountForUSSD(number: Double?): String {
         return try {
-            val formatter = DecimalFormat("###0.##")
+            val formatter = DecimalFormat("##0")
             formatter.maximumFractionDigits = 2
             formatter.minimumFractionDigits = 0
             formatter.format(number)


### PR DESCRIPTION
I noticed we're still having this issue.

<img width="196" alt="Screenshot 2022-12-19 at 3 57 31 PM" src="https://user-images.githubusercontent.com/24997980/208431342-e510ba9e-3828-4d37-9ea2-1ebd609e3f89.png">


The formatter is using decimals (the ```.##``` part of ```"###0.##"```), which will force ```456``` to be ```456.00``` and that's not what we want.

This PR is fixing that.