### PR TITLE
changed text color for download action button

### DIFF
--- a/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
+++ b/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
@@ -165,7 +165,7 @@ abstract class AbstractGoogleAuthActivity :
             }
             setActionTextColor(
                 ContextCompat.getColor(
-                    this@AbstractGoogleAuthActivity, R.color.stax_state_blue
+                    this@AbstractGoogleAuthActivity, R.color.white
                 )
             )
             show()


### PR DESCRIPTION
When a new update has been downloaded; the action button has no text.

Here's the bug:
![photo1672748370](https://user-images.githubusercontent.com/24997980/210356179-ba4457c4-a090-4098-a09f-b55bd24da7df.jpeg)

Also, should we change the text from "An update has just been downloaded" to something shorter so it's on one line? So something like "An update is ready to install" or "An update has been downloaded"
