### PR TITLE
Check Balance Succeeded Fix on Senders Institution 

### DIFF
--- a/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsFragment.kt
+++ b/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsFragment.kt
@@ -219,6 +219,7 @@ class TransactionDetailsFragment : AbstractBalanceCheckerFragment() {
                 binding.details.institutionValue.setSubtitle(Paybill.extractBizNumber(action))
             showBonusAmount(it.amount, action)
         }
+        binding.details.fromInstitutionValue.setTitle(action.from_institution_name)
         binding.statusInfo.institutionLogo.loadImage(requireContext(), getString(R.string.root_url) + action.from_institution_logo)
     }
 

--- a/app/src/main/res/layout/transaction_details_info_card.xml
+++ b/app/src/main/res/layout/transaction_details_info_card.xml
@@ -86,9 +86,7 @@
     </TableRow>
 
     <TableRow
-            android:layout_marginTop="@dimen/margin_18"
-            android:layout_marginBottom="@dimen/margin_34">
-
+            android:layout_marginTop="@dimen/margin_18">
         <TextView
                 android:text="@string/type_label"
                 android:textColor="@color/offWhite"
@@ -100,6 +98,21 @@
                 android:textAlignment="viewEnd"
                 android:textColor="@color/offWhite"
                 android:textSize="@dimen/text_16" />
+    </TableRow>
+
+    <TableRow
+        android:id="@+id/fromInstitutionRow"
+        android:layout_marginTop="@dimen/margin_18">
+
+        <TextView
+            android:text="@string/from_institution"
+            android:textColor="@color/offWhite"
+            android:textSize="@dimen/text_16" />
+
+        <com.hover.stax.views.Stax2LineItem
+            android:id="@+id/fromInstitutionValue"
+            android:layout_weight="1"
+            android:textAlignment="viewEnd" />
     </TableRow>
 
     <TableRow

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -854,5 +854,6 @@
     <string name="welcome">Welcome to Stax %1$s</string>
     <string name="welcome_back">Welcome back to Stax %1$s</string>
     <string name="signed_in_message">You are already signed in to Stax</string>
+    <string name="from_institution">Sender\'s institution</string>
 
 </resources>


### PR DESCRIPTION
This PR adds the Senders Institution which doesn't show up on the Transaction Details Screen for succeeded check balance. 

Fixes #939  🦕
