### PR TITLE
Fix Pending Status persists for all successful transactions

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/app/src/main/java/com/hover/stax/accounts/AccountsViewModel.kt
+++ b/app/src/main/java/com/hover/stax/accounts/AccountsViewModel.kt
@@ -97,7 +97,7 @@ class AccountsViewModel(application: Application, val repo: AccountRepo, val act
     private fun loadActions(account: Account, type: String) = viewModelScope.launch(Dispatchers.IO) {
         institutionActions.postValue(
             if (type == HoverAction.P2P) actionRepo.getTransferActions(account.institutionId!!, account.countryAlpha2!!)
-            else actionRepo.getActions(account.institutionId!!, account.countryAlpha2!!, type)
+            else actionRepo.getActions(account.institutionId, account.countryAlpha2!!, type)
         )
     }
 

--- a/app/src/main/java/com/hover/stax/database/AppDatabase.kt
+++ b/app/src/main/java/com/hover/stax/database/AppDatabase.kt
@@ -93,6 +93,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "stax.db"
                 )
+                    .enableMultiInstanceInvalidation()
                     .setJournalMode(JournalMode.WRITE_AHEAD_LOGGING)
                     .addMigrations(
                         Migrations.M23_24,

--- a/app/src/main/java/com/hover/stax/presentation/sims/SimViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/sims/SimViewModel.kt
@@ -46,13 +46,11 @@ class SimViewModel(private val listSimsUseCase: ListSimsUseCase, val application
                 fetchSims()
             }
         }
-
         loadSims()
     }
 
     private fun loadSims() {
         fetchSims()
-
         simReceiver?.let {
             LocalBroadcastManager.getInstance(application)
                 .registerReceiver(it, IntentFilter(Utils.getPackage(application) + ".NEW_SIM_INFO_ACTION"))


### PR DESCRIPTION
This PR fixes the pending status that persists after all successful transactions.

Fixes #[965](https://github.com/UseHover/Stax/issues/965) and  #[961](https://github.com/UseHover/Stax/issues/961)🦕
