### PR TITLE
Cleanup android editable to android inputType to use valid phone number

### DIFF
--- a/app/src/main/java/com/hover/stax/views/StaxDropdownLayout.kt
+++ b/app/src/main/java/com/hover/stax/views/StaxDropdownLayout.kt
@@ -34,7 +34,7 @@ open class StaxDropdownLayout(context: Context, attrs: AttributeSet) : AbstractS
     lateinit var autoCompleteTextView: AutoCompleteTextView
     private var hint: String? = null
     private var defaultText: String? = null
-    private var editable = false
+    private var inputType:String? = null
     private var imeOptions = 0
 
     @CallSuper
@@ -43,7 +43,7 @@ open class StaxDropdownLayout(context: Context, attrs: AttributeSet) : AbstractS
         try {
             hint = a.getString(R.styleable.StaxDropdownLayout_android_hint)
             defaultText = a.getString(R.styleable.StaxDropdownLayout_android_text)
-            editable = a.getBoolean(R.styleable.StaxDropdownLayout_android_editable, false)
+            inputType = a.getString(R.styleable.StaxDropdownLayout_android_inputType)
             imeOptions = a.getInt(R.styleable.StaxDropdownLayout_android_imeOptions, 0)
         } finally {
             a.recycle()
@@ -67,7 +67,7 @@ open class StaxDropdownLayout(context: Context, attrs: AttributeSet) : AbstractS
     private fun fillAttrs() {
         if (hint != null) (findViewById<View>(R.id.inputLayout) as TextInputLayout).hint = hint
         autoCompleteTextView.inputType =
-            if (editable) InputType.TYPE_TEXT_VARIATION_FILTER else InputType.TYPE_NULL
+            if (inputType !=null) InputType.TYPE_CLASS_PHONE else InputType.TYPE_NULL
         if (!defaultText.isNullOrEmpty()) autoCompleteTextView.setText(
             defaultText
         )

--- a/app/src/main/res/layout/contact_input.xml
+++ b/app/src/main/res/layout/contact_input.xml
@@ -24,7 +24,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:editable="true"
+            android:inputType="phone"
             android:hint="@string/recipientphone_label"
             tools:layout="@layout/stax_dropdown" />
 

--- a/app/src/main/res/layout/stax_dropdown.xml
+++ b/app/src/main/res/layout/stax_dropdown.xml
@@ -33,6 +33,7 @@
             android:dropDownWidth="wrap_content"
             android:dropDownHeight="wrap_content"
             android:drawablePadding="@dimen/margin_8"
+            android:inputType="phone"
             android:imeOptions="actionDone"
             android:textColor="@color/offWhite"
             android:autofillHints="phone"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -36,7 +36,7 @@
 
     <declare-styleable name="StaxDropdownLayout">
         <attr name="android:hint" />
-        <attr name="android:editable" />
+        <attr name="android:inputType" />
         <attr name="android:text" />
         <attr name="android:imeOptions" />
     </declare-styleable>


### PR DESCRIPTION
This PR updates android:editable which has been deprecated to use  android: inputType on the Contact phone number TextField. This would ensure the user would enter a valid phone number. 

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x ] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests are added/updated (if necessary)
- [ ] Ensure the linter passes (`./codeAnalysis` to automatically apply formatting/linting)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1001  🦕
