### PR TITLE
Injecting viewmodel to abstract class fix

### DIFF
--- a/app/src/main/java/com/hover/stax/bounty/BountyRepository.kt
+++ b/app/src/main/java/com/hover/stax/bounty/BountyRepository.kt
@@ -20,6 +20,8 @@ import com.hover.stax.countries.CountryAdapter
 import com.hover.stax.data.actions.ActionRepo
 import com.hover.stax.database.models.Channel
 import com.hover.stax.database.models.StaxTransaction
+import com.hover.stax.di.Dispatcher
+import com.hover.stax.di.StaxDispatchers
 import com.hover.stax.model.Bounty
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -44,7 +46,7 @@ interface BountyRepository {
 
 class BountyRepositoryImpl @Inject constructor(
     val actionRepo: ActionRepo,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @Dispatcher(StaxDispatchers.IO) private val coroutineDispatcher: CoroutineDispatcher
 ) : BountyRepository {
 
     override val bountyActions: List<HoverAction>

--- a/app/src/main/java/com/hover/stax/di/DispatchersModule.kt
+++ b/app/src/main/java/com/hover/stax/di/DispatchersModule.kt
@@ -1,0 +1,17 @@
+package com.hover.stax.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DispatchersModule {
+
+    @Provides
+    @Dispatcher(StaxDispatchers.IO)
+    fun providesIODispatcher(): CoroutineDispatcher = Dispatchers.IO
+}

--- a/app/src/main/java/com/hover/stax/di/StaxDispatchers.kt
+++ b/app/src/main/java/com/hover/stax/di/StaxDispatchers.kt
@@ -1,0 +1,13 @@
+package com.hover.stax.di
+
+import javax.inject.Qualifier
+import kotlin.annotation.AnnotationRetention.RUNTIME
+
+@Qualifier
+@Retention(RUNTIME)
+annotation class Dispatcher(val staxDispatcher: StaxDispatchers)
+
+enum class StaxDispatchers {
+    Default,
+    IO,
+}

--- a/app/src/main/java/com/hover/stax/domain/use_case/bounties/GetChannelBountiesUseCase.kt
+++ b/app/src/main/java/com/hover/stax/domain/use_case/bounties/GetChannelBountiesUseCase.kt
@@ -28,8 +28,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
 
-class GetChannelBountiesUseCase(
+class GetChannelBountiesUseCase @Inject constructor(
     private val channelRepository: ChannelRepository,
     private val bountyRepository: BountyRepository,
     private val transactionRepo: TransactionRepo

--- a/app/src/main/java/com/hover/stax/domain/use_case/sims/ListSimsUseCase.kt
+++ b/app/src/main/java/com/hover/stax/domain/use_case/sims/ListSimsUseCase.kt
@@ -20,8 +20,11 @@ import com.hover.sdk.sims.SimInfo
 import com.hover.stax.data.actions.ActionRepo
 import com.hover.stax.database.models.Account
 import com.hover.stax.data.accounts.AccountRepository
+import com.hover.stax.di.Dispatcher
+import com.hover.stax.di.StaxDispatchers
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
 data class SimWithAccount(
     val sim: SimInfo,
@@ -30,11 +33,11 @@ data class SimWithAccount(
     val airtimeActions: List<HoverAction?> = emptyList()
 )
 
-class ListSimsUseCase(
+class ListSimsUseCase @Inject constructor(
     private val simRepository: com.hover.stax.data.sim.SimInfoRepository,
     private val accountRepository: AccountRepository,
     private val actionRepository: ActionRepo,
-    private val defaultDispatcher: CoroutineDispatcher
+    @Dispatcher(StaxDispatchers.IO) private val defaultDispatcher: CoroutineDispatcher
 ) {
 
     suspend operator fun invoke(): List<SimWithAccount> = withContext(defaultDispatcher) {

--- a/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
+++ b/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
@@ -129,10 +129,10 @@ abstract class AbstractGoogleAuthActivity :
         ).apply {
             setAction(getString(R.string.restart)) {
                 updateManager.completeUpdate(); installListener?.let {
-                updateManager.unregisterListener(
-                    it
-                )
-            }
+                    updateManager.unregisterListener(
+                        it
+                    )
+                }
             }
             setActionTextColor(
                 ContextCompat.getColor(

--- a/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
+++ b/app/src/main/java/com/hover/stax/login/AbstractGoogleAuthActivity.kt
@@ -17,11 +17,8 @@ package com.hover.stax.login
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
@@ -35,10 +32,8 @@ import com.google.android.play.core.install.model.UpdateAvailability.UPDATE_AVAI
 import com.hover.stax.BuildConfig
 import com.hover.stax.R
 import com.hover.stax.core.Utils
-import com.hover.stax.presentation.bounties.BountyApplicationFragmentDirections
 import com.hover.stax.utils.UIHelper
 import timber.log.Timber
-import javax.inject.Inject
 
 const val FORCED_VERSION = "force_update_app_version"
 
@@ -46,8 +41,8 @@ abstract class AbstractGoogleAuthActivity :
     AppCompatActivity(),
     StaxGoogleLoginInterface {
 
-    @Inject
-    lateinit var loginViewModel: LoginViewModel
+    protected abstract fun provideLoginViewModel(): LoginViewModel
+
     private lateinit var staxGoogleLoginInterface: StaxGoogleLoginInterface
 
     private lateinit var updateManager: AppUpdateManager
@@ -55,8 +50,6 @@ abstract class AbstractGoogleAuthActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        initGoogleAuth()
-        setLoginObserver()
 
         updateManager = AppUpdateManagerFactory.create(this)
 
@@ -81,34 +74,6 @@ abstract class AbstractGoogleAuthActivity :
     fun setGoogleLoginInterface(staxGoogleLoginInterface: StaxGoogleLoginInterface) {
         this.staxGoogleLoginInterface = staxGoogleLoginInterface
     }
-
-    private fun initGoogleAuth() {
-        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestIdToken(getString(R.string.google_server_client_id)).requestEmail().build()
-        loginViewModel.signInClient = GoogleSignIn.getClient(this, gso)
-    }
-
-    private fun setLoginObserver() = with(loginViewModel) {
-        error.observe(this@AbstractGoogleAuthActivity) {
-            it?.let { staxGoogleLoginInterface.googleLoginFailed() }
-        }
-
-        googleUser.observe(this@AbstractGoogleAuthActivity) {
-            it?.let { staxGoogleLoginInterface.googleLoginSuccessful() }
-        }
-    }
-
-    fun signIn() = loginForResult.launch(loginViewModel.signInClient.signInIntent)
-
-    private val loginForResult =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            if (result.resultCode == RESULT_OK) {
-                loginViewModel.signIntoGoogle(result.data)
-            } else {
-                Timber.e("Google sign in failed")
-                staxGoogleLoginInterface.googleLoginFailed()
-            }
-        }
 
     private fun checkForUpdates() {
         val updateInfoTask = updateManager.appUpdateInfo
@@ -189,10 +154,6 @@ abstract class AbstractGoogleAuthActivity :
                 checkForUpdates()
             }
         }
-    }
-
-    override fun googleLoginSuccessful() {
-        if (loginViewModel.staxUser.value?.isMapper == true) BountyApplicationFragmentDirections.actionBountyApplicationFragmentToBountyListFragment()
     }
 
     override fun googleLoginFailed() {

--- a/app/src/main/java/com/hover/stax/merchants/MerchantViewModel.kt
+++ b/app/src/main/java/com/hover/stax/merchants/MerchantViewModel.kt
@@ -28,10 +28,12 @@ import com.hover.stax.database.models.BUSINESS_NO
 import com.hover.stax.database.models.Merchant
 import com.hover.stax.database.repo.ContactRepo
 import com.hover.stax.transfers.AbstractFormViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@HiltViewModel
 class MerchantViewModel @Inject constructor(
     application: Application,
     contactRepo: ContactRepo,

--- a/app/src/main/java/com/hover/stax/onboarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/hover/stax/onboarding/OnBoardingActivity.kt
@@ -32,11 +32,15 @@ import com.hover.stax.permissions.PermissionUtils
 import com.hover.stax.utils.NavUtil
 import com.hover.stax.utils.UIHelper
 import com.hover.stax.core.Utils
+import com.hover.stax.login.LoginViewModel
 
 class OnBoardingActivity : AbstractGoogleAuthActivity() {
 
     private lateinit var binding: OnboardingLayoutBinding
     private lateinit var navController: NavController
+    override fun provideLoginViewModel(): LoginViewModel {
+        TODO("Not yet implemented")
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         UIHelper.setFullscreenView(this)
@@ -86,6 +90,10 @@ class OnBoardingActivity : AbstractGoogleAuthActivity() {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         PermissionUtils.logPermissionsGranted(grantResults, this)
         checkPermissionsAndNavigate()
+    }
+
+    override fun googleLoginSuccessful() {
+        TODO("Not yet implemented")
     }
 
     private fun navigateToMainActivity() {

--- a/app/src/main/java/com/hover/stax/presentation/bounties/BountyScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/bounties/BountyScreen.kt
@@ -37,7 +37,7 @@ import com.hover.stax.presentation.bounties.components.ChannelBountiesCardPrevie
 import com.hover.stax.presentation.bounties.components.ChannelBountyCard
 import com.hover.stax.presentation.bounties.components.CountryDropdown
 import com.hover.stax.presentation.bounties.components.CountryDropdownPreview
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 
 const val CODE_ALL_COUNTRIES = "00"
 

--- a/app/src/main/java/com/hover/stax/presentation/bounties/BountyViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/bounties/BountyViewModel.kt
@@ -29,6 +29,7 @@ import com.hover.stax.countries.CountryAdapter
 import com.hover.stax.domain.use_case.bounties.GetChannelBountiesUseCase
 import com.hover.stax.core.Utils.getPackage
 import com.hover.stax.model.Bounty
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,7 +40,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
+@HiltViewModel
 class BountyViewModel @Inject constructor(
     private val simRepository: com.hover.stax.data.sim.SimInfoRepository,
     private val bountiesUseCase: GetChannelBountiesUseCase,

--- a/app/src/main/java/com/hover/stax/presentation/bounties/components/BountyLi.kt
+++ b/app/src/main/java/com/hover/stax/presentation/bounties/components/BountyLi.kt
@@ -40,7 +40,7 @@ import com.hover.stax.R
 import com.hover.stax.model.Bounty
 import com.hover.stax.presentation.bounties.BountySelectEvent
 import com.hover.stax.presentation.bounties.BountyViewModel
-import com.hover.stax.ui.theme.Brutalista
+import com.hover.stax.views.theme.Brutalista
 
 @Composable
 fun BountyLi(bounty: Bounty, bountyViewModel: BountyViewModel) {

--- a/app/src/main/java/com/hover/stax/presentation/components/StaxButton.kt
+++ b/app/src/main/java/com/hover/stax/presentation/components/StaxButton.kt
@@ -36,12 +36,12 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.hover.stax.ui.theme.Border
-import com.hover.stax.ui.theme.BrightBlue
-import com.hover.stax.ui.theme.ColorPrimary
-import com.hover.stax.ui.theme.OffWhite
-import com.hover.stax.ui.theme.TextGrey
-import com.hover.stax.ui.theme.mainBackground
+import com.hover.stax.views.theme.Border
+import com.hover.stax.views.theme.BrightBlue
+import com.hover.stax.views.theme.ColorPrimary
+import com.hover.stax.views.theme.OffWhite
+import com.hover.stax.views.theme.TextGrey
+import com.hover.stax.views.theme.mainBackground
 
 const val SECONDARY = 0
 const val PRIMARY = 1

--- a/app/src/main/java/com/hover/stax/presentation/components/StaxCard.kt
+++ b/app/src/main/java/com/hover/stax/presentation/components/StaxCard.kt
@@ -24,8 +24,8 @@ import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.hover.stax.ui.theme.Border
-import com.hover.stax.ui.theme.mainBackground
+import com.hover.stax.views.theme.Border
+import com.hover.stax.views.theme.mainBackground
 
 @Composable
 fun StaxCard(content: @Composable ColumnScope.() -> Unit) {

--- a/app/src/main/java/com/hover/stax/presentation/financial_tips/FinancialTipsViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/financial_tips/FinancialTipsViewModel.kt
@@ -19,12 +19,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hover.stax.model.Resource
 import com.hover.stax.domain.use_case.financial_tips.TipsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
+@HiltViewModel
 class FinancialTipsViewModel @Inject constructor(
     private val tipsUseCase: TipsUseCase
 ) : ViewModel() {

--- a/app/src/main/java/com/hover/stax/presentation/home/BalanceScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/BalanceScreen.kt
@@ -29,7 +29,7 @@ import com.hover.stax.database.models.Account
 import com.hover.stax.presentation.home.components.BalanceHeader
 import com.hover.stax.presentation.home.components.BalanceItem
 import com.hover.stax.presentation.home.components.EmptyBalance
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 
 interface BalanceTapListener {
     fun onTapBalanceRefresh(account: Account?)

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeScreen.kt
@@ -17,6 +17,7 @@ package com.hover.stax.presentation.home
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.text.format.DateUtils
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -34,7 +35,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.hover.sdk.actions.HoverAction
 import com.hover.stax.R
 import com.hover.stax.addChannels.ChannelsViewModel
-import com.hover.stax.model.FinancialTip
 import com.hover.stax.presentation.home.components.BalanceHeader
 import com.hover.stax.presentation.home.components.BalanceItem
 import com.hover.stax.presentation.home.components.BonusCard
@@ -43,7 +43,7 @@ import com.hover.stax.presentation.home.components.FinancialTipCard
 import com.hover.stax.presentation.home.components.GuideCard
 import com.hover.stax.presentation.home.components.PrimaryFeatures
 import com.hover.stax.presentation.home.components.TopBar
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 
 data class HomeClickFunctions(
     val onSendMoneyClicked: () -> Unit,
@@ -137,7 +137,7 @@ fun HomeScreen(
                         homeState?.financialTips?.let { financialTips ->
                             item {
                                 financialTips.firstOrNull {
-                                    android.text.format.DateUtils.isToday(it.date!!)
+                                    DateUtils.isToday(it.date!!)
                                 }?.let {
                                     if (homeState?.dismissedTipId != it.id)
                                         FinancialTipCard(

--- a/app/src/main/java/com/hover/stax/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/HomeViewModel.kt
@@ -23,7 +23,7 @@ import com.hover.sdk.actions.HoverAction
 import com.hover.stax.data.accounts.AccountRepository
 import com.hover.stax.data.actions.ActionRepo
 import com.hover.stax.domain.use_case.financial_tips.TipsUseCase
-import com.hover.stax.model.Resource
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
@@ -32,6 +32,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
+@HiltViewModel
 class HomeViewModel @Inject constructor(
     private val accountsRepo: AccountRepository,
     private val actionRepo: ActionRepo,

--- a/app/src/main/java/com/hover/stax/presentation/home/components/EmptyBalance.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/components/EmptyBalance.kt
@@ -34,9 +34,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.hover.stax.R
-import com.hover.stax.ui.theme.ColorSurface
-import com.hover.stax.ui.theme.DarkGray
-import com.hover.stax.ui.theme.OffWhite
+import com.hover.stax.views.theme.ColorSurface
+import com.hover.stax.views.theme.DarkGray
+import com.hover.stax.views.theme.OffWhite
 
 @Composable
 fun EmptyBalance(onClickedAddAccount: () -> Unit) {

--- a/app/src/main/java/com/hover/stax/presentation/home/components/GuideCard.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/components/GuideCard.kt
@@ -44,9 +44,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.hover.stax.R
-import com.hover.stax.ui.theme.OffWhite
-import com.hover.stax.ui.theme.StaxCardBlue
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.OffWhite
+import com.hover.stax.views.theme.StaxCardBlue
+import com.hover.stax.views.theme.StaxTheme
 
 @Composable
 fun GuideCard(message: String, buttonString: String, onClick: () -> Unit) {

--- a/app/src/main/java/com/hover/stax/presentation/home/components/VerticalImageTextView.kt
+++ b/app/src/main/java/com/hover/stax/presentation/home/components/VerticalImageTextView.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.hover.stax.R
-import com.hover.stax.ui.theme.BrightBlue
+import com.hover.stax.views.theme.BrightBlue
 
 @Composable
 fun VerticalImageTextView(

--- a/app/src/main/java/com/hover/stax/presentation/rewards/RewardsScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/rewards/RewardsScreen.kt
@@ -31,7 +31,7 @@ import com.hover.stax.presentation.rewards.components.PointsHeader
 import com.hover.stax.presentation.rewards.components.RecentPointsHeader
 import com.hover.stax.presentation.rewards.components.RewardActions
 import com.hover.stax.presentation.rewards.components.RewardsHistoryItem
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 
 @Composable
 fun RewardsScreen() {

--- a/app/src/main/java/com/hover/stax/presentation/rewards/components/ActionItem.kt
+++ b/app/src/main/java/com/hover/stax/presentation/rewards/components/ActionItem.kt
@@ -37,9 +37,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hover.stax.R
-import com.hover.stax.ui.theme.BrightBlue
-import com.hover.stax.ui.theme.OffWhite
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.BrightBlue
+import com.hover.stax.views.theme.OffWhite
+import com.hover.stax.views.theme.StaxTheme
 
 @Composable
 fun ActionItem(points: Int, action: String, onClick: () -> Unit) {

--- a/app/src/main/java/com/hover/stax/presentation/rewards/components/PointsDistributionDetail.kt
+++ b/app/src/main/java/com/hover/stax/presentation/rewards/components/PointsDistributionDetail.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.hover.stax.R
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 
 @Composable
 fun PointsDistributionDetail(actionList: List<RewardActions>) {

--- a/app/src/main/java/com/hover/stax/presentation/rewards/components/PointsHeader.kt
+++ b/app/src/main/java/com/hover/stax/presentation/rewards/components/PointsHeader.kt
@@ -39,9 +39,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.hover.stax.R
-import com.hover.stax.ui.theme.BrightBlue
-import com.hover.stax.ui.theme.StaxTheme
-import com.hover.stax.ui.theme.TextColorDark
+import com.hover.stax.views.theme.BrightBlue
+import com.hover.stax.views.theme.StaxTheme
+import com.hover.stax.views.theme.TextColorDark
 
 @Composable
 fun PointsHeader(points: Int, onClickRedeem: () -> Unit) {

--- a/app/src/main/java/com/hover/stax/presentation/rewards/components/RecentPointsHeader.kt
+++ b/app/src/main/java/com/hover/stax/presentation/rewards/components/RecentPointsHeader.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import com.hover.stax.R
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 
 @Composable
 fun RecentPointsHeader(onClickRefresh: () -> Unit) {

--- a/app/src/main/java/com/hover/stax/presentation/rewards/components/RewardsHistoryItem.kt
+++ b/app/src/main/java/com/hover/stax/presentation/rewards/components/RewardsHistoryItem.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.hover.stax.R
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 
 @Composable
 fun RewardsHistoryItem() {

--- a/app/src/main/java/com/hover/stax/presentation/sims/SimScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/sims/SimScreen.kt
@@ -46,8 +46,8 @@ import com.hover.stax.presentation.home.components.TopBar
 import com.hover.stax.presentation.sims.components.LinkSimCard
 import com.hover.stax.presentation.sims.components.SampleSimInfoProvider
 import com.hover.stax.presentation.sims.components.SimItem
-import com.hover.stax.ui.theme.StaxTheme
-import com.hover.stax.ui.theme.TextGrey
+import com.hover.stax.views.theme.StaxTheme
+import com.hover.stax.views.theme.TextGrey
 
 @Composable
 fun SimScreen(

--- a/app/src/main/java/com/hover/stax/presentation/sims/SimViewModel.kt
+++ b/app/src/main/java/com/hover/stax/presentation/sims/SimViewModel.kt
@@ -27,6 +27,7 @@ import com.hover.sdk.api.Hover
 import com.hover.stax.domain.use_case.sims.ListSimsUseCase
 import com.hover.stax.domain.use_case.sims.SimWithAccount
 import com.hover.stax.core.Utils
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -34,7 +35,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
-
+@HiltViewModel
 class SimViewModel @Inject constructor(
     private val listSimsUseCase: ListSimsUseCase,
     val application: Application

--- a/app/src/main/java/com/hover/stax/presentation/sims/components/LinkSimCards.kt
+++ b/app/src/main/java/com/hover/stax/presentation/sims/components/LinkSimCards.kt
@@ -36,10 +36,10 @@ import androidx.compose.ui.unit.dp
 import com.hover.stax.R
 import com.hover.stax.home.MainActivity
 import com.hover.stax.home.NavHelper
-import com.hover.stax.ui.theme.ColorSurface
-import com.hover.stax.ui.theme.DarkGray
-import com.hover.stax.ui.theme.OffWhite
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.ColorSurface
+import com.hover.stax.views.theme.DarkGray
+import com.hover.stax.views.theme.OffWhite
+import com.hover.stax.views.theme.StaxTheme
 
 @Composable
 internal fun LinkSimCard(@StringRes id: Int, stringArg: String = "") {

--- a/app/src/main/java/com/hover/stax/presentation/sims/components/SimItem.kt
+++ b/app/src/main/java/com/hover/stax/presentation/sims/components/SimItem.kt
@@ -47,7 +47,7 @@ import com.hover.stax.presentation.components.DisabledButton
 import com.hover.stax.presentation.components.PrimaryButton
 import com.hover.stax.presentation.components.SecondaryButton
 import com.hover.stax.presentation.components.StaxCard
-import com.hover.stax.ui.theme.TextGrey
+import com.hover.stax.views.theme.TextGrey
 import com.hover.stax.core.Utils
 
 @Composable

--- a/app/src/main/java/com/hover/stax/presentation/welcome/WelcomeFragment.kt
+++ b/app/src/main/java/com/hover/stax/presentation/welcome/WelcomeFragment.kt
@@ -33,8 +33,9 @@ import com.hover.stax.views.StaxDialog
 
 class WelcomeFragment : Fragment() {
 
+    // TODO - FIX THIS
     private var dialog: StaxDialog? = null
-    private val loginViewModel: LoginViewModel by viewModels()
+//    private val loginViewModel: LoginViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -44,7 +45,10 @@ class WelcomeFragment : Fragment() {
         ComposeView(requireContext()).apply {
             id = R.id.welcomeFragment
             setContent {
-                WelcomeScreen({ onClickGetStarted() }, { onClickLogin() }, showExploreButton = true)
+                WelcomeScreen({ onClickGetStarted() }, {
+//                    onClickLogin()
+                    onClickGetStarted()
+                                                       }, showExploreButton = true)
             }
         }
 
@@ -58,7 +62,7 @@ class WelcomeFragment : Fragment() {
             requireActivity()
         )
 
-        observeLoginProgress()
+//        observeLoginProgress()
     }
 
     private fun onClickGetStarted() {
@@ -72,28 +76,28 @@ class WelcomeFragment : Fragment() {
         )
     }
 
-    private fun onClickLogin() {
-        if (loginViewModel.staxUser.value != null) {
-            UIHelper.flashAndReportMessage(requireActivity(), getString(R.string.signed_in_message))
-            onClickGetStarted()
-        } else {
-            com.hover.stax.utils.AnalyticsUtil.logAnalyticsEvent(
-                getString(R.string.clicked_google_sign_in),
-                requireActivity()
-            )
-            (requireActivity() as MainActivity).signIn()
-        }
-    }
-
-    private fun observeLoginProgress() = with(loginViewModel) {
-        error.observe(viewLifecycleOwner) { it?.let { showError(it) } }
-        staxUser.observe(viewLifecycleOwner) {
-            if (it != null) {
-                showWelcomeMessage(it)
-                onClickGetStarted()
-            }
-        }
-    }
+//    private fun onClickLogin() {
+//        if (loginViewModel.staxUser.value != null) {
+//            UIHelper.flashAndReportMessage(requireActivity(), getString(R.string.signed_in_message))
+//            onClickGetStarted()
+//        } else {
+//            com.hover.stax.utils.AnalyticsUtil.logAnalyticsEvent(
+//                getString(R.string.clicked_google_sign_in),
+//                requireActivity()
+//            )
+//            (requireActivity() as MainActivity).signIn()
+//        }
+//    }
+//
+//    private fun observeLoginProgress() = with(loginViewModel) {
+//        error.observe(viewLifecycleOwner) { it?.let { showError(it) } }
+//        staxUser.observe(viewLifecycleOwner) {
+//            if (it != null) {
+//                showWelcomeMessage(it)
+//                onClickGetStarted()
+//            }
+//        }
+//    }
 
     private fun showError(message: String) {
         dialog = StaxDialog(requireActivity())

--- a/app/src/main/java/com/hover/stax/presentation/welcome/WelcomeFragment.kt
+++ b/app/src/main/java/com/hover/stax/presentation/welcome/WelcomeFragment.kt
@@ -25,8 +25,8 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.hover.stax.R
 import com.hover.stax.database.models.StaxUser
+import com.hover.stax.home.MainActivity
 import com.hover.stax.login.LoginViewModel
-import com.hover.stax.onboarding.OnBoardingActivity
 import com.hover.stax.utils.NavUtil
 import com.hover.stax.utils.UIHelper
 import com.hover.stax.views.StaxDialog
@@ -81,7 +81,7 @@ class WelcomeFragment : Fragment() {
                 getString(R.string.clicked_google_sign_in),
                 requireActivity()
             )
-            (requireActivity() as OnBoardingActivity).signIn()
+            (requireActivity() as MainActivity).signIn()
         }
     }
 

--- a/app/src/main/java/com/hover/stax/presentation/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/hover/stax/presentation/welcome/WelcomeScreen.kt
@@ -37,7 +37,7 @@ import com.hover.stax.presentation.welcome.components.ContinueButton
 import com.hover.stax.presentation.welcome.components.FeatureCard
 import com.hover.stax.presentation.welcome.components.GoogleSignInButton
 import com.hover.stax.presentation.welcome.components.WelcomeHeader
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 
 @Composable
 fun WelcomeScreen(

--- a/app/src/main/java/com/hover/stax/presentation/welcome/components/ContinueButton.kt
+++ b/app/src/main/java/com/hover/stax/presentation/welcome/components/ContinueButton.kt
@@ -24,8 +24,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.hover.stax.ui.theme.BrightBlue
-import com.hover.stax.ui.theme.ColorPrimaryDark
+import com.hover.stax.views.theme.BrightBlue
+import com.hover.stax.views.theme.ColorPrimaryDark
 
 // TODO change the button text to "Continue without signing in" or "Explore Stax"
 @Composable

--- a/app/src/main/java/com/hover/stax/presentation/welcome/components/GoogleSignInButton.kt
+++ b/app/src/main/java/com/hover/stax/presentation/welcome/components/GoogleSignInButton.kt
@@ -37,9 +37,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hover.stax.R
-import com.hover.stax.ui.theme.NavGrey
-import com.hover.stax.ui.theme.OffWhite
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.NavGrey
+import com.hover.stax.views.theme.OffWhite
+import com.hover.stax.views.theme.StaxTheme
 
 @Composable
 fun GoogleSignInButton(onClick: () -> Unit) {

--- a/app/src/main/java/com/hover/stax/requests/NewRequestViewModel.kt
+++ b/app/src/main/java/com/hover/stax/requests/NewRequestViewModel.kt
@@ -29,7 +29,6 @@ import com.hover.stax.database.models.Schedule
 import com.hover.stax.database.models.StaxContact
 import com.hover.stax.database.repo.ContactRepo
 import com.hover.stax.transfers.AbstractFormViewModel
-import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/hover/stax/requests/NewRequestViewModel.kt
+++ b/app/src/main/java/com/hover/stax/requests/NewRequestViewModel.kt
@@ -29,11 +29,14 @@ import com.hover.stax.database.models.Schedule
 import com.hover.stax.database.models.StaxContact
 import com.hover.stax.database.repo.ContactRepo
 import com.hover.stax.transfers.AbstractFormViewModel
+import dagger.hilt.android.HiltAndroidApp
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.util.Collections
 import javax.inject.Inject
 
+@HiltViewModel
 class NewRequestViewModel @Inject constructor(
     application: Application,
     val repo: RequestRepo,

--- a/app/src/main/java/com/hover/stax/schedules/ScheduleDetailViewModel.kt
+++ b/app/src/main/java/com/hover/stax/schedules/ScheduleDetailViewModel.kt
@@ -26,9 +26,11 @@ import com.hover.stax.data.schedule.ScheduleRepo
 import com.hover.stax.database.models.Schedule
 import com.hover.stax.database.models.StaxContact
 import com.hover.stax.database.repo.ContactRepo
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@HiltViewModel
 class ScheduleDetailViewModel @Inject constructor(
     val repo: ScheduleRepo,
     val actionRepo: ActionRepo,

--- a/app/src/main/java/com/hover/stax/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/hover/stax/settings/SettingsFragment.kt
@@ -43,6 +43,7 @@ import com.hover.stax.login.LoginViewModel
 import com.hover.stax.utils.NavUtil
 import com.hover.stax.utils.UIHelper
 import com.hover.stax.core.Utils
+import com.hover.stax.home.MainActivity
 import com.hover.stax.utils.collectLifecycleFlow
 import com.hover.stax.views.StaxDialog
 import kotlinx.coroutines.flow.StateFlow
@@ -376,7 +377,7 @@ class SettingsFragment : Fragment() {
     private fun startGoogleLogin() {
         binding.staxSupport.contactCard.showProgressIndicator()
         optInMarketing = true
-        (requireActivity() as AbstractGoogleAuthActivity).signIn()
+        (requireActivity() as MainActivity).signIn()
     }
 
     private fun marketingOptIn(optedIn: Boolean) {

--- a/app/src/main/java/com/hover/stax/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/hover/stax/settings/SettingsFragment.kt
@@ -36,7 +36,6 @@ import com.hover.stax.accounts.AccountsViewModel
 import com.hover.stax.database.models.Account
 import com.hover.stax.databinding.FragmentSettingsBinding
 import com.hover.stax.languages.LanguageViewModel
-import com.hover.stax.login.AbstractGoogleAuthActivity
 import com.hover.stax.login.LoginScreenUiState
 import com.hover.stax.login.LoginUiState
 import com.hover.stax.login.LoginViewModel

--- a/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsViewModel.kt
+++ b/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsViewModel.kt
@@ -36,12 +36,13 @@ import com.hover.stax.database.models.StaxContact
 import com.hover.stax.database.models.StaxTransaction
 import com.hover.stax.database.models.UssdCallResponse
 import com.hover.stax.database.repo.ContactRepo
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.json.JSONArray
 import timber.log.Timber
 import javax.inject.Inject
-
+@HiltViewModel
 class TransactionDetailsViewModel @Inject constructor(
     application: Application,
     val repo: TransactionRepo,

--- a/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsViewModel.kt
+++ b/app/src/main/java/com/hover/stax/transactionDetails/TransactionDetailsViewModel.kt
@@ -16,10 +16,12 @@
 package com.hover.stax.transactionDetails
 
 import android.app.Application
+import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import com.hover.sdk.actions.HoverAction
@@ -37,6 +39,7 @@ import com.hover.stax.database.models.StaxTransaction
 import com.hover.stax.database.models.UssdCallResponse
 import com.hover.stax.database.repo.ContactRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.json.JSONArray
@@ -44,14 +47,14 @@ import timber.log.Timber
 import javax.inject.Inject
 @HiltViewModel
 class TransactionDetailsViewModel @Inject constructor(
-    application: Application,
+    @ApplicationContext val context: Context,
     val repo: TransactionRepo,
     val actionRepo: ActionRepo,
     val contactRepo: ContactRepo,
     val accountRepo: AccountRepository,
     private val parserRepo: ParserRepo,
     private val merchantRepo: MerchantRepo
-) : AndroidViewModel(application) {
+) : ViewModel() {
 
     val transaction = MutableLiveData<StaxTransaction>()
     var account: LiveData<Account> = MutableLiveData()
@@ -135,7 +138,7 @@ class TransactionDetailsViewModel @Inject constructor(
     private fun generateSmsConvo(smsArr: JSONArray): ArrayList<UssdCallResponse> {
         val smses = ArrayList<UssdCallResponse>()
         for (i in 0 until smsArr.length()) {
-            val sms = getSMSMessageByUUID(smsArr.optString(i), getApplication())
+            val sms = getSMSMessageByUUID(smsArr.optString(i), context)
             Timber.e(sms.uuid)
             smses.add(
                 UssdCallResponse(

--- a/app/src/main/java/com/hover/stax/transactions/TransactionHistoryFragment.kt
+++ b/app/src/main/java/com/hover/stax/transactions/TransactionHistoryFragment.kt
@@ -25,7 +25,7 @@ import androidx.navigation.fragment.findNavController
 import com.hover.stax.R
 import com.hover.stax.databinding.TransactionCardHistoryBinding
 import com.hover.stax.presentation.home.components.TopBar
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 import com.hover.stax.utils.NavUtil
 import com.hover.stax.utils.UIHelper
 

--- a/app/src/main/java/com/hover/stax/transactions/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/hover/stax/transactions/TransactionHistoryViewModel.kt
@@ -26,10 +26,12 @@ import com.hover.stax.data.actions.ActionRepo
 import com.hover.stax.data.channel.ChannelRepository
 import com.hover.stax.data.transactions.TransactionRepo
 import com.hover.stax.database.models.StaxTransaction
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@HiltViewModel
 class TransactionHistoryViewModel @Inject constructor(
     private val repo: TransactionRepo,
     private val actionRepo: ActionRepo,

--- a/app/src/main/java/com/hover/stax/transfers/TransferViewModel.kt
+++ b/app/src/main/java/com/hover/stax/transfers/TransferViewModel.kt
@@ -27,11 +27,14 @@ import com.hover.stax.database.models.Request
 import com.hover.stax.database.models.StaxContact
 import com.hover.stax.database.repo.ContactRepo
 import com.yariksoffice.lingver.Lingver
+import dagger.hilt.android.HiltAndroidApp
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
+@HiltViewModel
 class TransferViewModel @Inject constructor(
     application: Application,
     private val requestRepo: RequestRepo,

--- a/app/src/main/java/com/hover/stax/transfers/TransferViewModel.kt
+++ b/app/src/main/java/com/hover/stax/transfers/TransferViewModel.kt
@@ -27,7 +27,6 @@ import com.hover.stax.database.models.Request
 import com.hover.stax.database.models.StaxContact
 import com.hover.stax.database.repo.ContactRepo
 import com.yariksoffice.lingver.Lingver
-import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/hover/stax/ussd_library/LibraryFragment.kt
+++ b/app/src/main/java/com/hover/stax/ussd_library/LibraryFragment.kt
@@ -33,7 +33,7 @@ import com.hover.stax.countries.CountryAdapter
 import com.hover.stax.database.models.Channel
 import com.hover.stax.databinding.FragmentLibraryBinding
 import com.hover.stax.presentation.home.components.TopBar
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 import com.hover.stax.utils.UIHelper
 import com.hover.stax.views.RequestServiceDialog
 import timber.log.Timber

--- a/app/src/main/java/com/hover/stax/views/theme/Color.kt
+++ b/app/src/main/java/com/hover/stax/views/theme/Color.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hover.stax.ui.theme
+package com.hover.stax.views.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/hover/stax/views/theme/Shape.kt
+++ b/app/src/main/java/com/hover/stax/views/theme/Shape.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hover.stax.ui.theme
+package com.hover.stax.views.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Shapes

--- a/app/src/main/java/com/hover/stax/views/theme/Theme.kt
+++ b/app/src/main/java/com/hover/stax/views/theme/Theme.kt
@@ -13,13 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hover.stax.ui.theme
+package com.hover.stax.views.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import com.hover.stax.views.theme.CardViewColor
+import com.hover.stax.views.theme.ColorPrimary
+import com.hover.stax.views.theme.ColorPrimaryDark
+import com.hover.stax.views.theme.OffWhite
+import com.hover.stax.views.theme.StaxStateRed
+import com.hover.stax.views.theme.mainBackground
 
 private val DarkColorPalette = darkColors(
     primary = ColorPrimary,

--- a/app/src/main/java/com/hover/stax/views/theme/Type.kt
+++ b/app/src/main/java/com/hover/stax/views/theme/Type.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hover.stax.ui.theme
+package com.hover.stax.views.theme
 
 import androidx.compose.material.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/test/java/com/hover/stax/presentation/welcome/WelcomeScreenTest.kt
+++ b/app/src/test/java/com/hover/stax/presentation/welcome/WelcomeScreenTest.kt
@@ -18,7 +18,7 @@ package com.hover.stax.presentation.welcome
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import com.hover.stax.ui.theme.StaxTheme
+import com.hover.stax.views.theme.StaxTheme
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/internal/database/src/main/java/com/hover/stax/database/di/DaosModule.kt
+++ b/internal/database/src/main/java/com/hover/stax/database/di/DaosModule.kt
@@ -17,6 +17,7 @@ package com.hover.stax.database.di
 
 import com.hover.sdk.actions.HoverActionDao
 import com.hover.sdk.database.HoverRoomDatabase
+import com.hover.sdk.parsers.ParserDao
 import com.hover.sdk.sims.SimInfoDao
 import com.hover.stax.database.StaxDatabase
 import com.hover.stax.database.dao.AccountDao
@@ -96,4 +97,9 @@ object DaosModule {
     fun providesHoverActionDao(
         database: HoverRoomDatabase,
     ): HoverActionDao = database.actionDao()
+
+    @Provides
+    fun providesParserDao(
+        database: HoverRoomDatabase,
+    ): ParserDao = database.parserDao()
 }


### PR DESCRIPTION
This PR fixes injecting loginviewmodel to the AbstractGoogleAuthActivity. 
Instead of injecting the viewmodel directly to the class, I added an abstract method provideLoginViewModel to the abstract class so I can use it to get an instance of the loginviewmodel on the MainActivity. 

Also, I annotated the viewmodels with @HiltViewModel. 

